### PR TITLE
First pass at fixes for broken links due to incubator change.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 #ruby=ruby-2.1.2
-#ruby-gemset=incubator-brooklyn-site
+#ruby-gemset=brooklyn-site
 
 source 'https://rubygems.org'
 ruby '2.1.2'

--- a/guide/dev/env/maven-build.md
+++ b/guide/dev/env/maven-build.md
@@ -105,20 +105,20 @@ although we'd love to if anyone can help!):
 [INFO] — maven-assembly-plugin:2.3:single (build-distribution-dir) @ brooklyn-dist —
 [INFO] Reading assembly descriptor: src/main/config/build-distribution-dir.xml
 {% comment %}BROOKLYN_VERSION{% endcomment %}[WARNING] Cannot include project artifact: io.brooklyn:brooklyn-dist:jar:0.9.0-SNAPSHOT; it doesn't have an associated file or directory.
-[INFO] Copying files to ~/repos/apache/incubator-brooklyn/usage/dist/target/brooklyn-dist
-[WARNING] Assembly file: ~/repos/apache/incubator-brooklyn/usage/dist/target/brooklyn-dist is not a regular file (it may be a directory). It cannot be attached to the project build for installation or deployment.
+[INFO] Copying files to ~/repos/apache/brooklyn/usage/dist/target/brooklyn-dist
+[WARNING] Assembly file: ~/repos/apache/brooklyn/usage/dist/target/brooklyn-dist is not a regular file (it may be a directory). It cannot be attached to the project build for installation or deployment.
 
 ...
 
 [INFO] — maven-assembly-plugin:2.3:single (build-distribution-archive) @ brooklyn-dist —
 [INFO] Reading assembly descriptor: src/main/config/build-distribution-archive.xml
 {% comment %}BROOKLYN_VERSION{% endcomment %}[WARNING] Cannot include project artifact: io.brooklyn:brooklyn-dist:jar:0.9.0-SNAPSHOT; it doesn't have an associated file or directory.
-{% comment %}BROOKLYN_VERSION{% endcomment %}[INFO] Building tar: /Users/aled/repos/apache/incubator-brooklyn/usage/dist/target/brooklyn-0.9.0-SNAPSHOT-dist.tar.gz
+{% comment %}BROOKLYN_VERSION{% endcomment %}[INFO] Building tar: /Users/aled/repos/apache/brooklyn/usage/dist/target/brooklyn-0.9.0-SNAPSHOT-dist.tar.gz
 {% comment %}BROOKLYN_VERSION{% endcomment %}[WARNING] Cannot include project artifact: io.brooklyn:brooklyn-dist:jar:0.9.0-SNAPSHOT; it doesn't have an associated file or directory.
 
 ...
 
-[WARNING] Don't override file /Users/aled/repos/apache/incubator-brooklyn/usage/archetypes/quickstart/target/test-classes/projects/integration-test-1/project/brooklyn-sample/src/main/resources/sample-icon.png
+[WARNING] Don't override file /Users/aled/repos/apache/brooklyn/usage/archetypes/quickstart/target/test-classes/projects/integration-test-1/project/brooklyn-sample/src/main/resources/sample-icon.png
 
 ...
 

--- a/guide/misc/download.md
+++ b/guide/misc/download.md
@@ -159,16 +159,16 @@ You can download archives of the source directly:
   <tr>
     <td style="vertical-align: middle;"><center>{{ site.brooklyn.git_branch }}</center></td>
     <td>
-<a href="https://github.com/apache/incubator-brooklyn/tarball/{{ site.brooklyn.git_branch }}"><img border="0" width="90" src="https://github.com/images/modules/download/tar.png"></a>
-<a href="https://github.com/apache/incubator-brooklyn/zipball/{{ site.brooklyn.git_branch }}"><img border="0" width="90" src="https://github.com/images/modules/download/zip.png"></a>
+<a href="https://github.com/apache/brooklyn/tarball/{{ site.brooklyn.git_branch }}"><img border="0" width="90" src="https://github.com/images/modules/download/tar.png"></a>
+<a href="https://github.com/apache/brooklyn/zipball/{{ site.brooklyn.git_branch }}"><img border="0" width="90" src="https://github.com/images/modules/download/zip.png"></a>
     </td>
   </tr>
 {% if site.brooklyn.git_branch != 'master' %}
   <tr>
     <td style="vertical-align: middle;"><center>master</center></td>
     <td>
-<a href="https://github.com/apache/incubator-brooklyn/tarball/master"><img border="0" width="90" src="https://github.com/images/modules/download/tar.png"></a>
-<a href="https://github.com/apache/incubator-brooklyn/zipball/master"><img border="0" width="90" src="https://github.com/images/modules/download/zip.png"></a>
+<a href="https://github.com/apache/brooklyn/tarball/master"><img border="0" width="90" src="https://github.com/images/modules/download/tar.png"></a>
+<a href="https://github.com/apache/brooklyn/zipball/master"><img border="0" width="90" src="https://github.com/images/modules/download/zip.png"></a>
     </td>
   </tr>
 {% endif %}

--- a/website/developers/committers/release-process/prerequisites.md
+++ b/website/developers/committers/release-process/prerequisites.md
@@ -11,18 +11,18 @@ Apache releases are posted to dist.apache.org, which is a Subversion repository.
 
 We have two directories here:
 
-- https://dist.apache.org/repos/dist/release/incubator/brooklyn - this is where IPMC approved releases go. Do not upload
-  here until we have a vote passed on dev@brooklyn and incubator-general. Check out this folder and name it
+- https://dist.apache.org/repos/dist/release/brooklyn - this is where IPMC approved releases go. Do not upload
+  here until we have a vote passed on dev@brooklyn. Check out this folder and name it
   `apache-dist-release-brooklyn`
-- https://dist.apache.org/repos/dist/dev/incubator/brooklyn - this is where releases to be voted on go. Make the release
+- https://dist.apache.org/repos/dist/dev/brooklyn - this is where releases to be voted on go. Make the release
   artifact, and post it here, then post the [VOTE] thread with links here. Check out this folder and name it
   `apache-dist-dev-brooklyn`.
 
 Example:
 
 {% highlight bash %}
-svn co https://dist.apache.org/repos/dist/release/incubator/brooklyn apache-dist-release-brooklyn
-svn co https://dist.apache.org/repos/dist/dev/incubator/brooklyn apache-dist-dev-brooklyn
+svn co https://dist.apache.org/repos/dist/release/brooklyn apache-dist-release-brooklyn
+svn co https://dist.apache.org/repos/dist/dev/brooklyn apache-dist-dev-brooklyn
 {% endhighlight %}
 
 When working with these folders, **make sure you are working with the correct one**, otherwise you may be publishing
@@ -76,7 +76,7 @@ Now add your key to the `apache-dist-release-brooklyn/KEYS` file:
 {% highlight bash %}
 cd apache-dist-release-brooklyn
 (gpg2 --list-sigs richard@apache.org && gpg2 --armor --export richard@apache.org) >> KEYS
-svn --username $SVN_USERNAME commit -m 'Update incubator/brooklyn/KEYS for $GPG_KEY'
+svn --username $SVN_USERNAME commit -m 'Update brooklyn/KEYS for $GPG_KEY'
 {% endhighlight %}
 
 References: 

--- a/website/developers/committers/release-process/publish-temp.md
+++ b/website/developers/committers/release-process/publish-temp.md
@@ -8,7 +8,7 @@ Publish the source and binary distributions to the pre-release area
 -------------------------------------------------------------------
 
 You will need to have checked out the Apache distribution Subversion repository located at
-https://dist.apache.org/repos/dist/dev/incubator/brooklyn. Please refer to [Prerequisites](prerequisites.html) for
+https://dist.apache.org/repos/dist/dev/brooklyn. Please refer to [Prerequisites](prerequisites.html) for
 information.
 
 In your workspace for the `dist.apache.org` repo, create a directory with the artifact name and version:
@@ -22,7 +22,7 @@ associated `.md5`, `.sha1`, `.sha256` and `.asc` signatures. Then commit:
 
 {% highlight bash %}
 svn add apache-brooklyn-${VERSION_NAME}-rc${RC_NUMBER}
-svn commit --message "Add apache-brooklyn-${VERSION_NAME}-rc${RC_NUMBER} to dist/dev/incubator/brooklyn"
+svn commit --message "Add apache-brooklyn-${VERSION_NAME}-rc${RC_NUMBER} to dist/dev/brooklyn"
 {% endhighlight %}
 
 These steps can be performed as part of the `make-release-artifacts.sh` script used earlier

--- a/website/developers/committers/release-process/publish.md
+++ b/website/developers/committers/release-process/publish.md
@@ -8,7 +8,7 @@ Publish the source and binary distributions to the pre-release area
 -------------------------------------------------------------------
 
 You will need to have checked out the Apache distribution Subversion repository located at
-https://dist.apache.org/repos/dist/release/incubator/brooklyn. Please refer to [Prerequisites](prerequisites.html) for
+https://dist.apache.org/repos/dist/release/brooklyn. Please refer to [Prerequisites](prerequisites.html) for
 information.
 
 In your workspace for the `dist.apache.org` repo, create a directory with the artifact name and version:
@@ -58,7 +58,7 @@ Then, add them to Subversion and commit.
 
 {% highlight bash %}
 svn add apache-brooklyn-${VERSION_NAME}
-svn commit --message "Add apache-brooklyn-${VERSION_NAME} to dist/release/incubator/brooklyn"
+svn commit --message "Add apache-brooklyn-${VERSION_NAME} to dist/release/brooklyn"
 {% endhighlight %}
 
 
@@ -97,7 +97,7 @@ mvn clean install -DskipTests
 Ensure the SVN repo is up-to-date (very painful otherwise!)
 
 {% highlight bash %}
-cd ${BROOKLYN_SITE_DIR-../incubator-brooklyn-site-public}
+cd ${BROOKLYN_SITE_DIR-../brooklyn-site-public}
 svn up
 cd -
 {% endhighlight %}
@@ -120,7 +120,7 @@ Update the "latest" docs to this release:
 Now publish _site/v/latest to the public website:
 
 {% highlight bash %}
-cd ${BROOKLYN_SITE_DIR-../../incubator-brooklyn-site-public}
+cd ${BROOKLYN_SITE_DIR-../../brooklyn-site-public}
 svn add * --force
 export DELETIONS=$( svn status | sed -e '/^!/!d' -e 's/^!//' )
 if [ ! -z "${DELETIONS}" ] ; then svn rm ${DELETIONS} ; fi

--- a/website/developers/committers/release-process/vote.md
+++ b/website/developers/committers/release-process/vote.md
@@ -12,7 +12,7 @@ taking a single argument being the staging repo link. For example:
 
     brooklyn-dist/release/print-vote-email.sh orgapachebrooklyn-1234 | pbcopy
 
-You should move the subject and put your name at the end, and simply eyeball the rest. This should be sent to **dev@brooklyn.incubator.apache.org**.
+You should move the subject and put your name at the end, and simply eyeball the rest. This should be sent to **dev@brooklyn.apache.org**.
 
 Alternatively, copy-paste the e-mail template below, being sure to substitute:
 
@@ -33,7 +33,7 @@ binary distribution, and Maven artifacts.
 
 The source and binary distributions, including signatures, digests, etc. can
 be found at:
-https://dist.apache.org/repos/dist/dev/incubator/brooklyn/apache-brooklyn-${VERSION_NAME}-rc${RC_NUMBER}
+https://dist.apache.org/repos/dist/dev/brooklyn/apache-brooklyn-${VERSION_NAME}-rc${RC_NUMBER}
 
 The artifact SHA-256 checksums are as follows:
 c3b5c581f14b44aed786010ac7c8c2d899ea0ff511135330395a2ff2a30dd5cf *apache-brooklyn-${VERSION_NAME}-rc${RC_NUMBER}-bin.tar.gz
@@ -48,11 +48,11 @@ All release artifacts are signed with the following key:
 https://people.apache.org/keys/committer/richard.asc
 
 KEYS file available here:
-https://dist.apache.org/repos/dist/release/incubator/brooklyn/KEYS
+https://dist.apache.org/repos/dist/release/brooklyn/KEYS
 
 The artifacts were built from Git commit ID
 24a23c5a4fd5967725930b8ceaed61dfbd225980
-https://git-wip-us.apache.org/repos/asf?p=incubator-brooklyn.git;a=commit;h=24a23c5a4fd5967725930b8ceaed61dfbd225980
+https://git-wip-us.apache.org/repos/asf?p=brooklyn.git;a=commit;h=24a23c5a4fd5967725930b8ceaed61dfbd225980
 
 
 Please vote on releasing this package as Apache Brooklyn ${VERSION_NAME}.
@@ -117,7 +117,7 @@ Note that you must find the URL for the previous thread at [mail-archives.apache
 The vote for releasing Apache Brooklyn ${VERSION_NAME} passed with 5 binding +1s, 1 non-binding +1s, and no 0 or -1.
 
 Vote thread link:
-https://mail-archives.apache.org/mod_mbox/incubator-brooklyn-dev/201507.mbox/%3CCABQFKi1WapCMRUqQ93E7Qow5onKgL3nyG3HW9Cse7vo%2BtUChRQ%40mail.gmail.com%3E
+https://mail-archives.apache.org/mod_mbox/brooklyn-dev/201507.mbox/%3CCABQFKi1WapCMRUqQ93E7Qow5onKgL3nyG3HW9Cse7vo%2BtUChRQ%40mail.gmail.com%3E
 
 Binding +1s:
 Hadrian Zbarcea (IPMC)


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/BROOKLYN-224.

Note there are still some references to "incubator" around voting processes that I was unsure about changing, e.g. references to general@incubator.