### PR TITLE
Fixes handling of undefined values in templates

### DIFF
--- a/style/js/catalog/common.js
+++ b/style/js/catalog/common.js
@@ -74,9 +74,9 @@ var brooklyn = (function ($, _) {
             "<div class='card configKey'>" +
             "<div class='name'><%=name%></div>" +
             "<dl>" +
-            "<dt>description</dt><dd><%=(description||'&nbsp;')%></dd>" +
-            "<dt>value type</dt><dd class='java'><%=(type||'&nbsp;')%></dd>" +
-            "<dt>default value</dt><dd><%=(defaultValue||'&nbsp;')%></dd>" +
+            "<dt>description</dt><dd><% if (typeof description !== 'undefined') { %><%= description %><% } else { %>&nbsp;<% } %></dd>" +
+            "<dt>value type</dt><dd class='java'><% if (typeof type !== 'undefined') { %><%= type %><% } else { %>&nbsp;<% } %></dd>" +
+            "<dt>default value</dt><dd><% if (typeof defaultValue !== 'undefined') { %><%= defaultValue %><% } else { %>&nbsp;<% } %></dd>" +
             "</dl>" +
             "</div>"
         ),
@@ -84,8 +84,8 @@ var brooklyn = (function ($, _) {
             "<div class='card sensor'>" +
             "<div class='name'><%=name%></div>" +
             "<dl>" +
-            "<dt>description</dt><dd><%=(description||'&nbsp;')%></dd>" +
-            "<dt>value type</dt><dd class='java'><%=(type||'&nbsp;')%></dd>" +
+            "<dt>description</dt><dd><% if (typeof description !== 'undefined') { %><%= description %><% } else { %>&nbsp;<% } %></dd>" +
+            "<dt>value type</dt><dd class='java'><% if (typeof type !== 'undefined') { %><%= type %><% } else { %>&nbsp;<% } %></dd>" +
             "</dl>" +
             "</div>"
         ),
@@ -93,8 +93,8 @@ var brooklyn = (function ($, _) {
             "<div class='card effector'>" +
             "<div class='name'><%=name%></div>" +
             "<dl>" +
-            "<dt>description</dt><dd><%=(description||'&nbsp;')%></dd>" +
-            "<dt>return type</dt><dd class='java'><%=(returnType||'&nbsp;')%></dd>" +
+            "<dt>description</dt><dd><% if (typeof description !== 'undefined') { %><%= description %><% } else { %>&nbsp;<% } %></dd>" +
+            "<dt>return type</dt><dd class='java'><% if (typeof returnType !== 'undefined') { %><%= returnType %><% } else { %>&nbsp;<% } %></dd>" +
             "</dl>" +
             "</div>"
         )

--- a/website/learnmore/catalog/catalog-item.html
+++ b/website/learnmore/catalog/catalog-item.html
@@ -90,15 +90,20 @@ under the License.
 
       document.title = 'Brooklyn ' + catalog_type + ' - ' + item.name;
 
-      item.config.forEach(function (element) { $("#configKeys").append(brooklyn.configKeyCard(element)); });
+      item.config.forEach(function (element) {
+        $("#configKeys").append(brooklyn.configKeyCard(element));
+      });
 
       if(args[0] == 'entities') {
         $("#sensorsTab").show();
         $("#effectorsTab").show();
-        
-        item.sensors.forEach(function (element) { $("#sensors").append(brooklyn.sensorCard(element)); });
+        item.sensors.forEach(function (element) {
+          $("#sensors").append(brooklyn.sensorCard(element));
+        });
         if (item.effectors != undefined) {
-          item.effectors.forEach(function (element) { $("#effectors").append(brooklyn.effectorCard(element)); });
+          item.effectors.forEach(function (element) {
+            $("#effectors").append(brooklyn.effectorCard(element));
+          });
         }
         
       } else {


### PR DESCRIPTION
https://brooklyn.apache.org/learnmore/catalog is currently broken for entities with config keys without default values (e.g. [BrooklynNode](https://brooklyn.apache.org/learnmore/catalog/catalog-item.html#!entities/org.apache.brooklyn.entity.brooklynnode.BrooklynNode)).