### PR TITLE
Fix BROOKLYN-271: ConfigKey card shows object hashCode of default values.

### DIFF
--- a/website/learnmore/catalog/catalog-item.html
+++ b/website/learnmore/catalog/catalog-item.html
@@ -91,7 +91,7 @@ under the License.
       document.title = 'Brooklyn ' + catalog_type + ' - ' + item.name;
 
       item.config.forEach(function (element) {
-        $("#configKeys").append(brooklyn.configKeyCard(element));
+        $("#configKeys").append(brooklyn.configKeyCard(deleteDefaultValueObjectId(element)));
       });
 
       if(args[0] == 'entities') {
@@ -110,6 +110,13 @@ under the License.
         $("#sensorsTab").hide();
         $("#effectorsTab").hide();
       }
+    }
+
+    function deleteDefaultValueObjectId(configkey){
+        if(_.isString(configkey.defaultValue)){
+            configkey.defaultValue = configkey.defaultValue.replace(/@[a-zA-Z0-9]+$/, "");
+        }
+        return configkey;
     }
 
     function getArgs() {


### PR DESCRIPTION
Fixing [BROOKLYN-271](https://issues.apache.org/jira/browse/BROOKLYN-271)
Avoiding object references in catalog ConfigKey cards, for example:

<img width="1036" alt="captura de pantalla 2016-05-19 a la s 17 46 04" src="https://cloud.githubusercontent.com/assets/3704424/15399867/992624fa-1de9-11e6-9e21-b9efe659ab1e.png">

Last picture shows that default value of `softwareProcess.lifecycleTasks` config key does not contain the object hashcode `@XXXXX`.