### PR TITLE
Ops guides updates for monitoring and disk space

### DIFF
--- a/guide/ops/index.md
+++ b/guide/ops/index.md
@@ -3,6 +3,7 @@ title: Operations
 started-pdf-exclude: true
 layout: website-normal
 children:
+- starting-stopping-monitoring.md
 - server-cli-reference.md
 - cli/
 - gui/

--- a/guide/ops/requirements.md
+++ b/guide/ops/requirements.md
@@ -19,6 +19,43 @@ at least 8GB RAM and 100GB disk. The disk is just for logs, a small amount of pe
 any binaries for custom blueprints/integrations.
 
 
+### Disk Space
+
+There are three main consumers of disk space:
+
+* **Static files**: these are the Apache Brooklyn files themselves, plus
+  binaries for custom blueprints and integrations added to the `lib` directory.
+* **Persisted state**: when using [Persistence](persistence/index.html) -- which
+  is a prerequisite for [High Availability](high-availability.html) -- Brooklyn
+  will save data to a store location. Items in the persisted state include
+  metadata about the Brooklyn servers, catalog items, and metadata about all
+  running applications and entities.
+* **Log files**: Brooklyn writes detailed log files by default to its own
+  installation directory. This can be reconfigured to change the destination
+  files, and increase or decrease the detail of the logs. See the
+  [Logging](logging.html) page for more details.
+
+
+The Apache Brooklyn distribution itself, when unpacked, consumes approximately
+75MB of disk space. The space consumed by additional binaries for custom
+blueprints and integrations is application-specific.
+
+Persisted state, excluding catalog data, is relatively small, starting at
+approximately 300KB for a clean, idle Brooklyn server. Deploying blueprints will
+add to this - how much depends exactly on the entities involved and is therefore
+application specific, but as a guideline, a 3-node Riak cluster adds
+approximately 500KB to the persistence store.
+
+Log data can be a large consumer of disk space. By default Brooklyn generates
+two logfiles, one which logs notable information only, and another which logs at
+a debug level. Each logfile rotates when it hits a size of 100MB; a maximum of
+10 log files are retained for each type. The two logging streams combined,
+therefore, can consume up to 2GB of disk space. In the default configuration
+logs are saved to the Brooklyn installation directory. You will most likely want
+to [reconfigure Brooklyn's logging](logging.html) to save logs to a location
+elsewhere, and to rotate logs according to your organisation's policy.
+
+
 ## Supported Operating Systems
 
 The recommended operating system is CentOS 6.x or RedHat 6.x.

--- a/guide/ops/requirements.md
+++ b/guide/ops/requirements.md
@@ -23,22 +23,24 @@ any binaries for custom blueprints/integrations.
 
 There are three main consumers of disk space:
 
-* **Static files**: these are the Apache Brooklyn files themselves, plus
-  binaries for custom blueprints and integrations added to the `lib` directory.
+* **Static files**: these are the Apache Brooklyn distribution with its own
+  dependencies, plus binaries for custom blueprints and integrations added to
+  the `lib` directory. Note that Brooklyn requires that Java is installed which
+  you may have to consider when calculating disk space requirements.
 * **Persisted state**: when using [Persistence](persistence/index.html) -- which
   is a prerequisite for [High Availability](high-availability.html) -- Brooklyn
   will save data to a store location. Items in the persisted state include
   metadata about the Brooklyn servers, catalog items, and metadata about all
   running applications and entities.
-* **Log files**: Brooklyn writes detailed log files by default to its own
-  installation directory. This can be reconfigured to change the destination
-  files, and increase or decrease the detail of the logs. See the
-  [Logging](logging.html) page for more details.
-
+* **Log files**: Brooklyn writes info and debug log files. By default, these are
+  written to the local filesystem. This can be reconfigured to set the
+  destination and to increase or decrease the detail in the logs. See the
+  [Logging](logging.html) section for more details.
 
 The Apache Brooklyn distribution itself, when unpacked, consumes approximately
-75MB of disk space. The space consumed by additional binaries for custom
-blueprints and integrations is application-specific.
+75MB of disk space. This includes everything needed to run Brooklyn except for a
+Java VM. The space consumed by additional binaries for custom blueprints and
+integrations is application-specific.
 
 Persisted state, excluding catalog data, is relatively small, starting at
 approximately 300KB for a clean, idle Brooklyn server. Deploying blueprints will
@@ -50,17 +52,21 @@ Log data can be a large consumer of disk space. By default Brooklyn generates
 two logfiles, one which logs notable information only, and another which logs at
 a debug level. Each logfile rotates when it hits a size of 100MB; a maximum of
 10 log files are retained for each type. The two logging streams combined,
-therefore, can consume up to 2GB of disk space. In the default configuration
+therefore, can consume up to 2GB of disk space.
+
+In the default configuration of Brooklyn's `.tar.gz` and `.zip` distributions,
 logs are saved to the Brooklyn installation directory. You will most likely want
 to [reconfigure Brooklyn's logging](logging.html) to save logs to a location
-elsewhere, and to rotate logs according to your organisation's policy.
+elsewhere. In the `.rpm` and `.deb` packaging, logging files will be located
+under `/var/log`. You can further reconfiguring the logging detail level and log
+rotation according to your organisation's policy.
 
 
 ## Supported Operating Systems
 
 The recommended operating system is CentOS 6.x or RedHat 6.x.
 
-Brooklyn has also been tested on Ubuntu 12.04 and OS X.
+Brooklyn has also been tested on Ubuntu 14.04 and OS X.
 
 
 ## Software Requirements

--- a/guide/ops/starting-stopping-monitoring.md
+++ b/guide/ops/starting-stopping-monitoring.md
@@ -1,0 +1,66 @@
+---
+title: Starting, Stopping and Monitoring
+layout: website-normal
+---
+
+**NOTE:** This document is for information on starting an Apache Brooklyn
+Server.  For information on using the Brooklyn Client CLI to access an already
+running Brooklyn Server, refer to [Client CLI Reference](cli/index.html).
+
+
+## Starting
+
+To launch Brooklyn, from the directory where Brooklyn is unpacked, run:
+
+{% highlight bash %}
+% bin/brooklyn launch > /dev/null 2>&1 & disown
+{% endhighlight %}
+
+With no configuration, this will launch the Brooklyn web console and REST API on [`http://localhost:8081/`](http://localhost:8081/).
+No password is set, but the server is listening only on the loopback network interface for security.
+Once [security is configured](brooklyn_properties.html), Brooklyn will listen on all network interfaces by default.
+
+See the [Server CLI Reference](server-cli-reference.html) for more information
+about the Brooklyn server process.
+
+The Brooklyn startup script will create a file name `pid_java` at the root of
+the Brooklyn directory, which contains the PID of the last Brooklyn process to
+be started.
+
+
+## Stopping
+
+To stop Brooklyn, simply send a `TERM` signal to the Brooklyn process. The PID
+of the most recently run Brooklyn process can be found in the `pid_java` file at
+the root of the Brooklyn directory.
+
+For example:
+
+{% highlight bash %}
+% kill $( cat pid_java )
+{% endhighlight bash %}
+
+
+## Monitoring
+
+As already mentioned, the Brooklyn startup script will create a file name
+`pid_java` at the root of the Brooklyn directory, which contains the PID of the
+last Brooklyn process to be started. You can examine this file to discover the
+PID, and then test that the process is still running.
+
+This should lead to a fairly straightforward integration with many monitoring
+tools - the monitoring tool can discover the expected PID, and can execute the
+start or stop commands shown above as necessary.
+
+For example, here is a fragment of a `monitrc` file as used by [Monit](http://https://mmonit.com/monit/):
+
+{% highlight text %}
+check process apachebrooklyn with pidfile /opt/apache-brooklyn/pid_java
+    start program = "/bin/bash -c '/opt/apache-brooklyn/bin/brooklyn launch & disown'" with timeout 10 seconds
+    stop  program = "/bin/bash -c 'kill $( cat /opt/apache-brooklyn/pid_java )'"
+{% endhighlight %}
+
+In addition to monitoring the Brooklyn process itself, you will almost certainly
+want to monitor resource usage of Brooklyn. In particular, please see the
+[Requirements](requirements.html#disk-space) section for a discussion on Brooklyn's disk
+space requirements.

--- a/guide/ops/starting-stopping-monitoring.md
+++ b/guide/ops/starting-stopping-monitoring.md
@@ -7,8 +7,21 @@ layout: website-normal
 Server.  For information on using the Brooklyn Client CLI to access an already
 running Brooklyn Server, refer to [Client CLI Reference](cli/index.html).
 
+## Packages for RHEL/CentOS and Ubuntu
 
-## Starting
+If you are using the `.rpm` or `.deb` package of Apache Brooklyn, then Brooklyn
+will integrate with your OS service management. Commands such as
+`service brooklyn start` will work as expected, and Brooklyn's PID file will be
+stored in the normal location for your OS, such as `/var/run/brooklyn.pid`.
+
+
+## Platform-independent distributions
+
+The platform-independent distributions are packaged in `.tar.gz` and `.zip`
+files.
+
+
+### Starting
 
 To launch Brooklyn, from the directory where Brooklyn is unpacked, run:
 
@@ -28,7 +41,7 @@ the Brooklyn directory, which contains the PID of the last Brooklyn process to
 be started.
 
 
-## Stopping
+### Stopping
 
 To stop Brooklyn, simply send a `TERM` signal to the Brooklyn process. The PID
 of the most recently run Brooklyn process can be found in the `pid_java` file at
@@ -43,20 +56,24 @@ For example:
 
 ## Monitoring
 
-As already mentioned, the Brooklyn startup script will create a file name
-`pid_java` at the root of the Brooklyn directory, which contains the PID of the
-last Brooklyn process to be started. You can examine this file to discover the
-PID, and then test that the process is still running.
+For `.tar.gz` and `.zip` distributions of Brooklyn, the Brooklyn startup script
+will create a file name `pid_java` at the root of the Brooklyn directory, which
+contains the PID of the last Brooklyn process to be started. You can examine
+this file to discover the PID, and then test that the process is still running.
+`.rpm` and `.deb` distributions of Brooklyn will use the normal mechanism that
+your OS uses, such as writing to `/var/run/brooklyn.pid`.
 
 This should lead to a fairly straightforward integration with many monitoring
 tools - the monitoring tool can discover the expected PID, and can execute the
 start or stop commands shown above as necessary.
 
-For example, here is a fragment of a `monitrc` file as used by [Monit](http://https://mmonit.com/monit/):
+For example, here is a fragment of a `monitrc` file as used by
+[Monit](http://https://mmonit.com/monit/), for a Brooklyn `.tar.gz` distribution
+unpacked and installed at `/opt/apache-brooklyn`:
 
 {% highlight text %}
 check process apachebrooklyn with pidfile /opt/apache-brooklyn/pid_java
-    start program = "/bin/bash -c '/opt/apache-brooklyn/bin/brooklyn launch & disown'" with timeout 10 seconds
+    start program = "/bin/bash -c '/opt/apache-brooklyn/bin/brooklyn launch --persist auto & disown'" with timeout 10 seconds
     stop  program = "/bin/bash -c 'kill $( cat /opt/apache-brooklyn/pid_java )'"
 {% endhighlight %}
 


### PR DESCRIPTION
Some additions to the User Guide "Operations" section, covering starting, monitoring and stopping the server, and a discussion of its disk space usage.