### PR TITLE
Catalog format more consistent

### DIFF
--- a/guide/java/gist_generator/gist_generator.bom
+++ b/guide/java/gist_generator/gist_generator.bom
@@ -1,10 +1,10 @@
 brooklyn.catalog:
   id: example.GistGenerator
-  version: 1.0
+  version: "1.0"
+  itemType: template
   description: For programmatically generating GitHub Gists
   displayName: Gist Generator
   iconUrl: classpath:///sample-icon.png
-  itemType: template
   libraries:
   - http://search.maven.org/remotecontent?filepath=com/google/code/gson/gson/2.2.2/gson-2.2.2.jar
   - http:/.developers.cloudsoftcorp.com/brooklyn/guide/java/gist_generator/org.eclipse.egit.github.core-2.1.5.jar

--- a/guide/misc/osgi.md
+++ b/guide/misc/osgi.md
@@ -88,6 +88,7 @@ For example, the `catalog.bom` file for Brooklyn's Webapp bundle looks like (abb
         version: ...
         items:
         - id: org.apache.brooklyn.entity.webapp.nodejs.NodeJsWebAppService
+          itemType: entity
           item:
             type: org.apache.brooklyn.entity.webapp.nodejs.NodeJsWebAppService
             name: Node.JS Application

--- a/guide/ops/externalized-configuration.md
+++ b/guide/ops/externalized-configuration.md
@@ -128,7 +128,8 @@ The same blueprint language DSL can be used within YAML catalog items. For examp
 
     brooklyn.catalog:
       id: com.example.myblueprint
-      version: 1.2.3
+      version: "1.2.3"
+      itemType: entity
       brooklyn.libraries:
       - >
         $brooklyn:formatString("https://%s:%s@repo.example.com/libs/myblueprint-1.2.3.jar", 

--- a/guide/yaml/entity-configuration.md
+++ b/guide/yaml/entity-configuration.md
@@ -49,7 +49,8 @@ The example below illustrates the principles:
 brooklyn.catalog:
   items:
   - id: entity-config-example
-    displayName: Entity Config Example
+    itemType: entity
+    name: Entity Config Example
     item:
       type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
       brooklyn.parameters:
@@ -182,8 +183,9 @@ parent entity's value will never be inherited:
 brooklyn.catalog:
   items:
   - id: entity-config-example
-    version: 1.1.0-SNAPSHOT
-    displayName: Entity Config Example
+    version: "1.1.0-SNAPSHOT"
+    itemType: entity
+    name: Entity Config Example
     item:
       type: org.apache.brooklyn.entity.machine.MachineEntity
       brooklyn.parameters:

--- a/guide/yaml/example_yaml/brooklyn-elasticsearch-catalog.bom
+++ b/guide/yaml/example_yaml/brooklyn-elasticsearch-catalog.bom
@@ -1,6 +1,7 @@
 brooklyn.catalog:
   id: elasticsearch
-  version: 1.0
+  version: "1.0"
+  itemType: entity
   iconUrl: https://avatars0.githubusercontent.com/u/6764390?v=3&s=400
   name: Elasticsearch
   license: Apache-2.0

--- a/guide/yaml/example_yaml/brooklyn-elk-catalog.bom
+++ b/guide/yaml/example_yaml/brooklyn-elk-catalog.bom
@@ -1,35 +1,34 @@
 brooklyn.catalog:
-  version: 1.0
+  id: ELK-Stack
+  version: "1.0"
+  itemType: template
   iconUrl: https://avatars0.githubusercontent.com/u/6764390?v=3&s=400
   license: Apache-2.0
   issues_url: https://github.com/Graeme-Miller/brooklyn-elk/issues
-  itemType: template
+  name: ELK Stack
+  description: |
+    Simple ELK stack deployment: provisions Elasticsearch, Kibana and Logtash as a child of Apache Tomcat 8
   item:
-    type: org.apache.brooklyn.entity.stock.BasicApplication
-    name: ELK Stack
-    id: ELK-Stack
-    description: |
-      Simple ELK stack deployment: provisions Elasticsearch, Kibana and Logtash as a child of Apache Tomcat 8
     services:
-      - type: elasticsearch
-        id: es
-        name:  Elasticsearch Cluster
+    - type: elasticsearch
+      id: es
+      name:  Elasticsearch Cluster
+      brooklyn.config:
+        install.version: 1.4.4
+    - type: kibana-standalone
+      id: kibana
+      name: Kibana Server
+      customize.latch: $brooklyn:entity("es").attributeWhenReady("service.isUp")
+      brooklyn.config:
+        kibana.elasticsearch.ip: $brooklyn:entity("es").attributeWhenReady("host.address.first")
+        kibana.elasticsearch.port: $brooklyn:entity("es").config("elasticsearch.http.port")
+    - type: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
+      id: tomcat
+      customize.latch: $brooklyn:entity("es").attributeWhenReady("service.isUp")
+      brooklyn.config:
+        children.startable.mode: background_late
+      brooklyn.children:
+      - type: logstash-child
+        name: Logstash Child
         brooklyn.config:
-          install.version: 1.4.4
-      - type: kibana-standalone
-        id: kibana
-        name: Kibana Server
-        customize.latch: $brooklyn:entity("es").attributeWhenReady("service.isUp")
-        brooklyn.config:
-          kibana.elasticsearch.ip: $brooklyn:entity("es").attributeWhenReady("host.address.first")
-          kibana.elasticsearch.port: $brooklyn:entity("es").config("elasticsearch.http.port")
-      - type: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
-        id: tomcat
-        customize.latch: $brooklyn:entity("es").attributeWhenReady("service.isUp")
-        brooklyn.config:
-          children.startable.mode: background_late
-        brooklyn.children:
-        - type: logstash-child
-          name: Logstash Child
-          brooklyn.config:
-            logstash.elasticsearch.host: $brooklyn:entity("es").attributeWhenReady("urls.http.withBrackets")
+          logstash.elasticsearch.host: $brooklyn:entity("es").attributeWhenReady("urls.http.withBrackets")

--- a/guide/yaml/example_yaml/brooklyn-kibana-catalog.bom
+++ b/guide/yaml/example_yaml/brooklyn-kibana-catalog.bom
@@ -1,8 +1,9 @@
 brooklyn.catalog:
-  version: 0.0.2
+  version: "0.0.2"
   iconUrl: http://blog.arungupta.me/wp-content/uploads/2015/07/kibana-logo.png
   items:
   - id: kibana-standalone
+    itemType: entity
     name: "Kibana server"
     description: "Single Kibana server"
     description: |

--- a/guide/yaml/example_yaml/brooklyn-logstash-catalog.bom
+++ b/guide/yaml/example_yaml/brooklyn-logstash-catalog.bom
@@ -1,8 +1,9 @@
 brooklyn.catalog:
-  version: 1.5.5
+  version: "1.5.5"
   iconUrl: http://logstash.net/images/logstash.png
   items:
   - id: logstash-standalone
+    itemType: entity
     name: "Logstash server"
     description: "Single Logstash server"
     item:
@@ -45,6 +46,7 @@ brooklyn.catalog:
         nohup /opt/logstash/logstash-${VERSION}/bin/logstash agent -f ${CONFIG_DIR} -l /var/log/logstash/logstash.log &
         echo $! > $PID_FILE
   - id: logstash-child
+    itemType: entity
     name: "Logstash Child"
     description: |
        Logstash server to be embedded as a child of a SoftwareProcess who

--- a/guide/yaml/example_yaml/vanilla-bash-netcat-catalog.bom
+++ b/guide/yaml/example_yaml/vanilla-bash-netcat-catalog.bom
@@ -1,6 +1,7 @@
 brooklyn.catalog:
   id: netcat-example
   version: "1.0"
+  itemType: entity
   item:
     type: org.apache.brooklyn.entity.software.base.VanillaSoftwareProcess
     name: Simple Netcat Server


### PR DESCRIPTION
See email discussion on dev@brookyn, subject "[PROPOSAL] catalog YAML format consistency".

This just does minor changes.

The biggest change is adding itemType in all our examples, and updates the docs to say that it's compulsory. It also wraps all the version numbers in quotes, and makes the metadata order more consistent (id, then version, then itemType).

Similar PRs to follow in the other repos, to change their brooklyn.catalog examples to include itemType.