### PR TITLE
Tidy up example brooklyn.properties

### DIFF
--- a/guide/start/brooklyn.properties
+++ b/guide/start/brooklyn.properties
@@ -31,62 +31,27 @@
 
 ## GUI Security
 
-## NOTE: in production it is highly recommended to set this, as otherwise it will not require login,
-## not will it be encrypted (though for safety if security is not set it will only bind to loopback)
+## NOTE: in production it is highly recommended to set up security.
+## See http://brooklyn.apache.org/v/latest/ops/brooklyn_properties.html#authentication
 
-## Edit the name(s) and passwords as appropriate to your system:
+## Edit the name(s) and passwords as appropriate to your system, or even better generate
+## a salt and sha256 of your password.
 
 # brooklyn.webconsole.security.users=admin,bob
 # brooklyn.webconsole.security.user.admin.password=password
 # brooklyn.webconsole.security.user.bob.password=bobsword
 
-## If you prefer to run with https (on port 8443 by default), uncomment this:
+## If you prefer to run with https (on port 8443 by default), either configure this on the
+## command line (see or http://brooklyn.apache.org/v/latest/ops/server-cli-reference.html#launch-command)
+## or uncomment this:
 
 # brooklyn.webconsole.security.https.required=true
-
-
-# By default we have AWS set up (but with invalid credentials!).  Many, many other
-# providers are supported.
-
-## Amazon EC2 Credentials
-# These should be an "Access Key ID" and "Secret Access Key" for your account.
-# This is configured at https://console.aws.amazon.com/iam/home?#security_credential .
-
-brooklyn.location.jclouds.aws-ec2.identity = AKA_YOUR_ACCESS_KEY_ID
-brooklyn.location.jclouds.aws-ec2.credential = <access-key-hex-digits>
-
-# Beware of trailing spaces in your cloud credentials. This will cause unexpected
-# 401: unauthorized responses.
-
-## Using Other Clouds
-# 1. Cast your eyes down this document to find your preferred cloud in the Named Locations
-#    section, and the examples.
-# 2. Uncomment the relevant line(s) for your provider.
-# 3. ADD  -.identity and -.credential lines for your provider, similar to the AWS ones above,
-#    replacing 'aws-ec2' with jcloud's id for your cloud.
-
-
-## Deploying to Localhost
-## see: info on locations at brooklyn.io
-#
-## ~/.ssh/id_rsa is Brooklyn's default location
-# brooklyn.location.localhost.privateKeyFile = ~/.ssh/id_rsa
-## Passphrases are supported, but not required
-# brooklyn.location.localhost.privateKeyPassphrase = s3cr3tpassphrase
-
-## Geoscaling Service - used for the Global Web Fabric demo
-## see: the global web example at brooklyn.io
-## https://www.geoscaling.com/dns2/
-## other services may take similar configuration similarly; or can usually be set in YAML
-# brooklyn.geoscaling.username = USERNAME
-# brooklyn.geoscaling.password = PASSWORD
-# brooklyn.geoscaling.primaryDomain = DOMAIN
-
 
 
 ##########################  Getting Started Complete!  ###################################
 
 # That's it, although you may want to read through these options...
+
 
 ################################ Brooklyn Options ########################################
 
@@ -115,11 +80,12 @@ brooklyn.location.jclouds.aws-ec2.credential = <access-key-hex-digits>
 ## Misc Cloud Settings
 ## brooklyn will fail a node if the cloud machine doesn't come up, but you can tell it to retry:
 # brooklyn.location.jclouds.machineCreateAttempts = 3
-## many cloud machines don't have sufficient entropy for lots of encrypted networking, so fake it:
-# brooklyn.location.jclouds.installDevUrandom=true
+## many cloud machines don't have sufficient entropy for lots of encrypted networking, so 
+## the default is to use /dev/urandom; disable that (to use /dev/random) by setting this to false:
+# brooklyn.location.jclouds.installDevUrandom=false
 
-## Sets a minimium ram property for all jclouds locations. Recommended to avoid getting m1.micros on AWS!
-brooklyn.location.jclouds.minRam = 2048
+## Sets a minimium ram property for all jclouds locations. Recommended to avoid getting tiny machines!
+# brooklyn.location.jclouds.minRam = 2048
 
 ## When setting up a new cloud machine Brooklyn creates a user with the same name as the user running
 ## Brooklyn on the management server, but you can force a different user here:
@@ -127,10 +93,63 @@ brooklyn.location.jclouds.minRam = 2048
 ## And you can force a password or key (by default it will use the keys in ~/.ssh/id_rsa{,.pub}
 # brooklyn.location.jclouds.password=s3cr3t
 
+
+############################ Deploying to Localhost #####################################
+
+## Deploying to Localhost
+## see: info on locations at http://brooklyn.apache.org/v/latest/ops/locations/index.html#localhost
+##
+## Brooklyn defaults to using ~/.ssh/id_rsa, if it exists.
+# brooklyn.location.localhost.privateKeyFile = ~/.ssh/id_rsa
+## Passphrases are supported, but not required
+# brooklyn.location.localhost.privateKeyPassphrase = s3cr3tpassphrase
+
+
+################################## Geoscaling ###########################################
+
+## Entities can retrieve their configuration from brooklyn.properties. However, it is 
+## more common to set this configuration in the blueprint's YAML.
+
+## The Geoscaling Service - used for the Global Web Fabric demo - can read the following
+## configurat (see http://www.geoscaling.com/dns2/)
+# brooklyn.geoscaling.username = USERNAME
+# brooklyn.geoscaling.password = PASSWORD
+# brooklyn.geoscaling.primaryDomain = DOMAIN
+
+
+############################# Locations Credentials #####################################
+
+## Best practice is to add locations to the catalog, rather than configuring locations
+## in brooklyn.properties. We also recommend using a proper credentials store, such as
+## Vault.
+##
+## However, brooklyn.properties is supported. Example configurations are shown below.
+
+## Amazon EC2 Credentials
+## These should be an "Access Key ID" and "Secret Access Key" for your account.
+## See http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html
+# brooklyn.location.jclouds.aws-ec2.identity = AKA_YOUR_ACCESS_KEY_ID
+# brooklyn.location.jclouds.aws-ec2.credential = <access-key-hex-digits>
+
+## Beware of trailing spaces in your cloud credentials. This will cause unexpected
+## 401: unauthorized responses.
+
+## Using Other Clouds
+## 1. Cast your eyes down this document to find your preferred cloud in the Named Locations
+##    section, and the examples.
+## 2. Uncomment the relevant line(s) for your provider.
+## 3. ADD  -.identity and -.credential lines for your provider, similar to the AWS ones above,
+##    replacing 'aws-ec2' with jcloud's id for your cloud.
+
+
 ################################ Named Locations ########################################
 
-# Named locations appear in the web console. If using the command line or YAML it may be 
-# just as easy to use the jclouds:<provider> locations and specify additional properties there.
+## Best practice is to add locations to the catalog, rather than using named locations in 
+## brooklyn.properties. However, the latter approach is supported. Example configurations
+## are shown below.
+
+## Named locations appear in the web console. If using the command line or YAML it may be 
+## just as easy to use the jclouds:<provider> locations and specify additional properties there.
 
 ## Example: AWS Virginia using Rightscale 6.3 64bit Centos AMI and Large Instances
 # brooklyn.location.named.aws-va-centos-large = jclouds:aws-ec2:us-east-1
@@ -147,10 +166,10 @@ brooklyn.location.jclouds.minRam = 2048
 # brooklyn.location.named.aws-acct-two-singapore.displayName = AWS Singapore (Acct Two)
 
 # For convenience some common defaults:
-brooklyn.location.named.aws-california = jclouds:aws-ec2:us-west-1
-brooklyn.location.named.aws-oregon = jclouds:aws-ec2:us-west-2
-brooklyn.location.named.aws-ireland = jclouds:aws-ec2:eu-west-1
-brooklyn.location.named.aws-tokyo = jclouds:aws-ec2:ap-northeast-1
+# brooklyn.location.named.aws-california = jclouds:aws-ec2:us-west-1
+# brooklyn.location.named.aws-oregon = jclouds:aws-ec2:us-west-2
+# brooklyn.location.named.aws-ireland = jclouds:aws-ec2:eu-west-1
+# brooklyn.location.named.aws-tokyo = jclouds:aws-ec2:ap-northeast-1
 
 ## Google Compute
 ## The credentials for GCE come from the "APIs & auth -> Credentials" page,
@@ -173,16 +192,6 @@ brooklyn.location.named.aws-tokyo = jclouds:aws-ec2:ap-northeast-1
 ## gce images often start with iptables turned on; turn it off unless your blueprints are iptables-aware 
 # brooklyn.location.jclouds.google-compute-engine.stopIptables=true
 
-## HP Cloud - also Ubuntu 12.04 LTS
-## You specify your HP Credentials like this:
-# brooklyn.location.jclouds.hpcloud-compute.identity = projectname:username
-# brooklyn.location.jclouds.hpcloud-compute.credential = password
-## where username and password are the same as logging in to the web console, and
-## projectname can be found here: https://account.hpcloud.com/projects
-# brooklyn.location.named.HP\ Cloud\ Arizona-1 = jclouds:hpcloud-compute:az-1.region-a.geo-1
-# brooklyn.location.named.HP\ Cloud\ Arizona-1.imageId = az-1.region-a.geo-1/75845
-# brooklyn.location.named.HP\ Cloud\ Arizona-1.user = ubuntu
-
 ## Softlayer - need a key from the gui, under "administrative -> user administration -> api-access 
 # brooklyn.location.jclouds.softlayer.identity=username
 # brooklyn.location.jclouds.softlayer.credential=<private-key-hex-digits>
@@ -195,7 +204,7 @@ brooklyn.location.named.aws-tokyo = jclouds:aws-ec2:ap-northeast-1
 
 
 ## Brooklyn uses the jclouds multi-cloud library to access many clouds.
-## http://www.jclouds.org/documentation/reference/supported-providers/
+## https://jclouds.apache.org/reference/providers/#compute
 
 ## Templates for many other clouds, but remember to add identity and credentials:
 
@@ -311,27 +320,28 @@ brooklyn.location.named.aws-tokyo = jclouds:aws-ec2:ap-northeast-1
 ## abiquo identity and credential are your login username/passed
 # brooklyn.location.named.My\ Abiquo=jclouds:abiquo:http://demonstration.abiquo.com/api/
 
+
 ###############################  Formatting Guide  #######################################
 
-! Both # and ! mark lines as comments
+## Both # and ! mark lines as comments
 # The follow syntax are ALL valid.
 # example_key example_value
 # example_key : example_value
 # example_key = example_value
 # example_key=example_value
 
-# The backslash below tells Brooklyn to continue reading the value onto the next line.
+## The backslash below tells Brooklyn to continue reading the value onto the next line.
 # example_key = A very \
 #          	long string!
-# Note all white space before 'long...' is ignored. Also '!' is kept as part of the string
+## Note all white space before 'long...' is ignored. Also '!' is kept as part of the string
 
 
-# Keys with spaces should be escaped with backslashes.
-# This is useful for named locations, as the name displayed in Brooklyn's web
-# interface is derived from the key name.
+## Keys with spaces should be escaped with backslashes.
+## This is useful for named locations, as the name displayed in Brooklyn's web-console
+## is derived from the key name.
 # key\ with\ spaces = some\ value
 
-# Encoding for .properties must be ISO-8859-1, aka Latin-1.
-# All non-latin1 characters must be entered using unicode escape characters
+## Encoding for .properties must be ISO-8859-1, aka Latin-1.
+## All non-latin1 characters must be entered using unicode escape characters
 # polish_pangram = P\u00F3jd\u017A\u017Ce, ki\u0144 \
 #                  t\u0119 chmurno\u015B\u0107 w g\u0142\u0105b flaszy!


### PR DESCRIPTION
* Tell people that the catalog is the recommended way to configure
  locations.
* Move AWS out of “Getting Started”. The user can add a location via
  the UI; that is what we should encourage.
* Remove HP Cloud, because that service no longer exists.
* Fix a few links.
* installDevUrandom now defaults to true; update comment.
* comment out everything (including AWS creds example) as we want to
  encourage use of catalog.