### PR TITLE
Change Mitaka instructions

### DIFF
--- a/guide/ops/locations/_openstack.md
+++ b/guide/ops/locations/_openstack.md
@@ -274,4 +274,4 @@ If you do not have `openstack-mitaka-nova`, you can build and install it using t
   by building: https://github.com/cloudsoft/jclouds-openstack-mitaka-nova
 * If using Karaf, install this bundle (e.g. `bundle:install mvn:io.cloudsoft.jclouds.api/openstack-mitaka-nova/1.9.3-cloudsoft.20160831`),
   and start it (e.g. `bundle:start openstack-mitaka-nova`).
-* Or if using the old-style main, copy the jar into the `lib/dropins` directory and retart.
+* Or if using the old-style main, copy the jar into the `lib/patch` directory and retart.


### PR DESCRIPTION
If a user follows these instructions after following the previous devtest ones, these will fail to work. If they are instructed to use the `patch` folder, they will.