### PR TITLE
Remove bash prompt chars

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -23,10 +23,8 @@ under the License.
 
 {{ content }}
 
-
-<script src="{{ site.path.style }}/js/zeroclipboard/ZeroClipboard.min.js"></script>
-
 <script language="JavaScript" type="application/javascript">
+
     fix_padding_function = function () { 
         $('body').css('padding-top', parseInt($('#header').css("height"))+10);
         $('body').css('padding-bottom', parseInt($('#footer').css("height"))+10);
@@ -65,31 +63,69 @@ $(function () {
     }
 });
 
-<!-- Clipboard support -->
-  ZeroClipboard.config({ moviePath: '{{ site.path.style }}/js/zeroclipboard/ZeroClipboard.swf' });
+<!-- Copying and clipboard support -->
+
+// first make the $% line starts not selectable 
+
+$(function() {
+  $('div.highlight').attr('oncopy', 'handleHideCopy(this)');
+  $('div.highlight').each(function(index,target) {
+    if ($(target).find('code.bash')) {
+      // Mark bash prompts from the start of each line (i.e. '$' or '%' characters
+      // at the very start, or immediately following any newline) as not-selectable. 
+      // Handle continuation lines where a leading '$' or '%' is *not* a prompt character.
+      // (If example wants to exclude output, it can manually use class="nocopy".)
+      target.innerHTML = target.innerHTML.replace(/(^\s*|[^\\]\n)(<.*>)?([$%]|&gt;) /g, '$1$2<span class="nocopy bash_prompt">$3 </span>');
+    }
+  });
+});
+
+// normal cmd-C (non-icon) copying
+
+function handleHideCopy(el) {
+//    var origHtml = $(el).clone();
+    console.log("handling copy", el);
+    $(el).addClass('copying');
+    $(el).find('.nocopy').hide();
+    $(el).find('.clipboard_button').addClass('manual-clipboard-is-active');
+    setTimeout(function(){
+        $(el).removeClass('copying');
+        $(el).find('.clipboard_button').removeClass('manual-clipboard-is-active');
+        $(el).find('.nocopy').show();
+//        $(el).html(origHtml);
+    }, 600);
+}
+
+// and icon (flash) copying
+
+</script>
+
+<script src="{{ site.path.style }}/js/zeroclipboard/ZeroClipboard.min.js"></script>
+
+<script language="JavaScript" type="application/javascript">
+
+ZeroClipboard.config({ moviePath: '{{ site.path.style }}/js/zeroclipboard/ZeroClipboard.swf' });
 
 $(function() {
   $('div.highlight').prepend(
-  $('<div class="clipboard_container" title="Copy to Clipboard">'+
-    '<div class="fa clipboard_button">'+
-    '<div class="on-active"><div>Copied to Clipboard</div></div>'+
-  '</div></div>'));
+    $('<div class="clipboard_container" title="Copy to Clipboard">'+
+      '<div class="fa clipboard_button">'+
+      '<div class="on-active"><div>Copied to Clipboard</div></div>'+
+    '</div></div>'));
   $('div.clipboard_container').each(function(index) {
     var clipboard = new ZeroClipboard();
     clipboard.clip( $(this).find(":first")[0], $(this)[0] );
-    var target = $(this).next();
-    var txt = target.text().trim();
-    if (target.find('code.bash')) {
-      // Strip out bash prompts from the start of each line (i.e. '$' or '%' characters
-      // at the very start, or immediately following any newline). Correctly handles continuation
-      // lines, where a leading '$' or '%' is *not* a prompt character.
-      txt = txt.replace(/(^|[^\\]\n)[$%] /g, "$1");
-    }
+    var target0 = $(this).next();
+    var target = target0.clone();
+    target.find('.nocopy').remove();
+    var txt = target.text();
     clipboard.on( 'dataRequested', function (client, args) {
+      handleHideCopy( target0.closest('div.highlight') );  //not necessary but nicer feedback
       client.setText( txt );
     });
   });
 });
+
 
 <!-- search -->
     $(function() {

--- a/guide/start/policies.md
+++ b/guide/start/policies.md
@@ -355,8 +355,8 @@ Tomcat on the vagrant VMs named "byon1" to "byon4":
 
 {% highlight bash %}
 $ for i in byon{1..4}; do
-$   vagrant ssh ${i} --command 'ps aux | grep -i tomcat |  grep -v grep | awk '\''{print $2}'\'' | xargs kill -9'
-$ done
+>   vagrant ssh ${i} --command 'ps aux | grep -i tomcat |  grep -v grep | awk '\''{print $2}'\'' | xargs kill -9'
+> done
 {% endhighlight %}
 
 You can view the state of the Tomcat server with the command below (which drills into the  
@@ -437,12 +437,12 @@ you could use a load generator like jmeter, or use a script such as the one show
 {% highlight bash %}
 $ URL=http://10.10.10.101:8000/
 $ for i in {1..600}; do
-$   for j in {1..50}; do 
-$     curl -saefafefj  ${URL} > /dev/null || echo "Curl failed with exit code $?"
-$   done
-$   echo "Finished batch $i"
-$   sleep 1
-$ done
+>   for j in {1..50}; do 
+>     curl -saefafefj  ${URL} > /dev/null || echo "Curl failed with exit code $?"
+>   done
+>   echo "Finished batch $i"
+>   sleep 1
+> done
 {% endhighlight %}
 
 While those curl commands run in a separate terminal, you can look at the metrics for the first

--- a/guide/start/running.md
+++ b/guide/start/running.md
@@ -253,6 +253,6 @@ For details on the CLI, see the [Client CLI Reference]({{ site.path.guide }}/ops
 
 <div class="started-pdf-exclude">
 
-The first thing we want to do with Brooklyn is **[deploy a blueprint]({{ site.path.guide }}/ops/blueprints.html)**.
+The first thing we want to do with Brooklyn is **[deploy a blueprint]({{ site.path.guide }}/start/blueprints.html)**.
 
 </div>

--- a/style/css/_code_blocks.scss
+++ b/style/css/_code_blocks.scss
@@ -70,6 +70,9 @@ a code {
 .clipboard_button.zeroclipboard-is-active .on-active {
   display: inherit;
 }
+.clipboard_button.manual-clipboard-is-active .on-active {
+  display: inherit;
+}
 .clipboard_button .on-active {
   // z-index often doesn't help here (diff stacking context to the side menu)... but it shouldn't hurt!
   z-index: 10;
@@ -96,3 +99,10 @@ a code {
   padding: 3px 7px;
   @include transform('translateX(-50%)');
 }
+
+
+span.bash_prompt {
+  color: #bb60d5;
+  font-weight: bold;
+}
+

--- a/style/css/_code_blocks.scss
+++ b/style/css/_code_blocks.scss
@@ -100,9 +100,16 @@ a code {
   @include transform('translateX(-50%)');
 }
 
-
 span.bash_prompt {
   color: #bb60d5;
   font-weight: bold;
 }
 
+.nocopy {
+  // still experimental, and seems to affect rendering rather and not what is actually copied to clipboard
+  // our JS removes these blocks explicitly on copy events, but nice to add that it doesn't appear highlighted 
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+}


### PR DESCRIPTION
inspired by #97 (and replacing it) this uses the proper multi-line bash char, and ensures these chars are removed on copy-paste

uses a nice JS `oncopy` trick mentioned in the comments on that PR