### PR TITLE
tidy curl args

### DIFF
--- a/guide/start/policies.md
+++ b/guide/start/policies.md
@@ -438,7 +438,7 @@ you could use a load generator like jmeter, or use a script such as the one show
 $ URL=http://10.10.10.101:8000/
 $ for i in {1..600}; do
 >   for j in {1..50}; do 
->     curl -saefafefj  ${URL} > /dev/null || echo "Curl failed with exit code $?"
+>     curl --fail --silent ${URL} > /dev/null || echo "Curl failed with exit code $?"
 >   done
 >   echo "Finished batch $i"
 >   sleep 1


### PR DESCRIPTION
as discussed in #97 -- the old args looked really strange, at least on the os x `curl`.

would appreciate feedback from any of @drigodwin @duncangrant @Graeme-Miller @aledsage @grkvlt who might have some insight as to whether the old args were there for a reason.