### PR TITLE
Use brooklyn user for easier copy&paste

### DIFF
--- a/guide/ops/troubleshooting/increase-system-resource-limits.md
+++ b/guide/ops/troubleshooting/increase-system-resource-limits.md
@@ -12,15 +12,15 @@ On the VM running Apache Brooklyn, it is recommended that nproc and nofile are r
 (e.g. 16384 or higher; a value of 1024 is often the default).
 
 If you want to check the current limits run `ulimit -a`. Alternatively, if Brooklyn is run as a 
-different user (e.g. with user name "adalovelace"), then instead run `ulimit -a -u adalovelace`.
+different user (e.g. with user name "brooklyn"), then instead run `ulimit -a -u brooklyn`.
 
 For RHEL (and CentOS) distributions, you can increase the limits by running
-`sudo vi /etc/security/limits.conf` and adding (if it is "adalovelace" user running Apache Brooklyn):
+`sudo vi /etc/security/limits.conf` and adding (if it is "brooklyn" user running Apache Brooklyn):
 
-    adalovelace           soft    nproc           16384
-    adalovelace           hard    nproc           16384
-    adalovelace           soft    nofile          16384
-    adalovelace           hard    nofile          16384
+    brooklyn           soft    nproc           16384
+    brooklyn           hard    nproc           16384
+    brooklyn           soft    nofile          16384
+    brooklyn           hard    nofile          16384
 
 Generally you do not have to reboot to apply ulimit values. They are set per session.
 So after you have the correct values, quit the ssh session and log back in.


### PR DESCRIPTION
The brooklyn user is the most common one used for running instances (created by the rpm & deb packages).