### PR TITLE
fixed mis-spelling by removing Broo(o)klyn

### DIFF
--- a/guide/yaml/yaml-reference.md
+++ b/guide/yaml/yaml-reference.md
@@ -1,5 +1,5 @@
 ---
-title: Broooklyn YAML Blueprint Reference
+title: YAML Blueprint Reference
 layout: website-normal
 ---
 


### PR DESCRIPTION
Page reads just as well without Brooklyn ref.