### PR TITLE
Add deprecated functionality which can't be communicated to the user otherwise

### DIFF
--- a/guide/misc/release-notes.md
+++ b/guide/misc/release-notes.md
@@ -17,9 +17,15 @@ to Brooklyn's commercial users for funding much of this development.
 
 ### Backwards Compatibility
 
-Changes since 0.9.0:
+Changes since 0.10.0:
 
-1. ...
+1. The usage of `ManagementContext.getConfig()` is deprecated for storing non-config data like
+singletons and cached objects. Use `ManagementContext.getScratchpad()` instead. Affected objects:
+
+  * BrooklynCampConstants.CAMP_PLATFORM
+  * CampYamlParser.YAML_PARSER_KEY
+  * BrooklynServiceAttributes.BROOKLYN_REST_OBJECT_MAPPER
+  * BrooklynWebConfig.SECURITY_PROVIDER_INSTANCE
 
 
 For changes in prior versions, please refer to the release notes for 


### PR DESCRIPTION
Can't be communicated to the user by deprecating APIs or logging.

Follow up to https://github.com/apache/brooklyn-server/pull/562.