### PR TITLE
Brooklyn.initializers example with sensor from windows command

### DIFF
--- a/guide/yaml/custom-entities.md
+++ b/guide/yaml/custom-entities.md
@@ -243,6 +243,21 @@ so that the `$message` we passed above gets logged and reported back:
           period: 1s
           command: tail -1 server-input
 
+##### Windows Command Sensor
+
+Like the blueprint above, the following example also uses brooklyn.initializers to define sensors on the entity,
+this time however it is a windows VM and uses `WinRmCommandSensor`.
+
+    - type: org.apache.brooklyn.entity.software.base.VanillaWindowsProcess
+      brooklyn.config:
+        launch.command: echo launching
+        checkRunning.command: echo running
+      brooklyn.initializers:
+      - type: org.apache.brooklyn.core.sensor.windows.WinRmCommandSensor
+        brooklyn.config:
+          name: ip.config
+          period: 60s
+          command: hostname
 
 #### Summary
 

--- a/guide/yaml/yaml-reference.md
+++ b/guide/yaml/yaml-reference.md
@@ -58,9 +58,10 @@ the entity being defined, with these being the most common:
     and optionally a `period`, to create a sensor feed which populates the sensor with
     the given name by running the given command (on an entity which as an ssh-able machine)
 
-  * `org.apache.brooklyn.core.sensor.windows.WinRmCommandSensor`: For command supplied via WinRm. Takes a `name` and `command`,
-    and optionally a `period`, to create a sensor feed which populates the sensor with
-    the given name by running the given command (on an entity which as an winrm-able machine)
+  * `org.apache.brooklyn.core.sensor.windows.WinRmCommandSensor`: For a command supplied via WinRm. Takes a `name`, `command`,
+    and optionally a `period` and `executionDir`, to create a sensor feed which populates the sensor with
+    the given name by running the given command (on an entity which as an winrm-able machine).<br/>
+    _`"~"` will use the default execution directory for the WinRm session which is usually `%USERPROFILE%`_
 
 * `brooklyn.parameters`: documents a list of typed parameters the entity accepts. If none
   are specified the config keys declared in the entity's class are used (including the


### PR DESCRIPTION
`org.apache.brooklyn.core.sensor.windows.WinRmCommandSensor` is already listed in `brooklyn-docs/guide/yaml/yaml-reference.md` but it could be nice to have it here as well.