### PR TITLE
Add docs for enricher.producer values

### DIFF
--- a/guide/dev/tips/index.md
+++ b/guide/dev/tips/index.md
@@ -9,24 +9,24 @@ title: Miscellaneous Tips and Tricks
   do it in a project under the ``sandbox`` directory.
   This means we can accept pulls more easily (as sandbox items aren't built as part of the main build)
   and speed up collaboration.
-  
+
 * When debugging an entity, make sure the  [brooklyn.SSH logger](logging.html) is set to DEBUG and accessible.
- 
+
 * Use tests heavily!  These are pretty good to run in the IDE (once you've completed [IDE setup]({{site.path.guide}}/dev/env/ide/)),
   and far quicker to spot problems than runtime, plus we get early-warning of problems introduced in the future.
   (In particular, Groovy's laxity with compilation means it is easy to introduce silly errors which good test coverage will find much faster.)
-  
+
 * If you hit inexplicable problems at runtime, try clearing your Maven caches,
   or the brooklyn-relevant parts, under ``~/.m2/repository``.
   Also note your IDE might be recompiling at the same time as a Maven command-line build,
   so consider turning off auto-build.
-  
-* When a class or method becomes deprecated, always include ``@deprecated`` in the Javadoc 
+
+* When a class or method becomes deprecated, always include ``@deprecated`` in the Javadoc
   e.g. "``@deprecated since 0.7.0; instead use {@link ...}``"
   * Include when it was deprecated
   * Suggest what to use instead -- e.g. link to alternative method, and/or code snippet, etc.
-  * Consider logging a warning message when a deprecated method or config option is used, 
-    saying who is using it (e.g. useful if deprecated config keys are used in yaml) -- 
+  * Consider logging a warning message when a deprecated method or config option is used,
+    saying who is using it (e.g. useful if deprecated config keys are used in yaml) --
     if it's a method which might be called a lot, some convenience for "warn once per entity" would be helpful)
   * See the [Java deprecation documentation](https://docs.oracle.com/javase/7/docs/technotes/guides/javadoc/deprecation/deprecation.html)
 
@@ -39,21 +39,32 @@ title: Miscellaneous Tips and Tricks
   sensors and config keys can be re-used.
   (Many are inherited from interfaces, where they are declared as constants,
   e.g. ``Attributes`` and ``UsesJmx``.)
-  
+
 * Understand the location hierarchy:  software process entities typically get an ``SshMachineLocation``,
   and use a ``*SshDriver`` to do what they need.  This will usually have a ``MachineProvisioningLocation`` parent, e.g. a
   ``JcloudsLocation`` (e.g. AWS eu-west-1 with credentials) or possibly a ``LocalhostMachineProvisioningLocation``.
   Clusters will take such a ``MachineProvisioningLocation`` (or a singleton list); fabircs take a list of locations.
   Some PaaS systems have their own location model, such as ``OpenShiftLocation``.
 
-Finally, don't be shy about [talking with others]({{site.path.website}}/community/), 
-that's far better than spinning your wheels (or worse, having a bad experience),
-plus it means we can hopefully improve things for other people!
+* Finally, don't be shy about [talking with others]({{site.path.website}}/community/),
+  that's far better than spinning your wheels (or worse, having a bad experience),
+  plus it means we can hopefully improve things for other people!
 
+## YAML Blueprint Debugging
+
+* Brooklyn will reject any YAML blueprint that contains syntax errors and will alert the user of such errors.
+
+* However, it is possible to create a blueprint that is syntactically legal but results in runtime problems
+  for Brooklyn (for example, if an enricher's `enricher.producer` value is not immediately resolvable).
+
+* If Brooklyn appears to freeze after deploying a blueprint, run the `jstack <brooklyn-pid>` command to view
+  the state of all running threads. By examining this output, it may become obvious which thread(s) are causing
+  the problem, and the details of the stack trace will provide insight into which part of the blueprint is
+  incorrectly written.
 
 ## Project Maintenance
 
 * Adding a new project may need updates to ``/pom.xml`` ``modules`` section and ``usage/all`` dependencies
- 
+
 * Adding a new example project may need updates to ``/pom.xml`` and ``/examples/pom.xml`` (and the documentation too!)
 

--- a/guide/java/policies.md
+++ b/guide/java/policies.md
@@ -4,14 +4,14 @@ layout: website-normal
 
 ---
 
-Policies perform the active management enabled by Brooklyn.  
+Policies perform the active management enabled by Brooklyn.
 They can subscribe to entity sensors and be triggered by them (or they can run periodically,
 or be triggered by external systems).
 
 <!---
 TODO, clarify below, members of what?
 -->
-Policies can add subscriptions to sensors on any entity. Normally a policy will subscribe to its 
+Policies can add subscriptions to sensors on any entity. Normally a policy will subscribe to its
 associated entity, to the child entities, and/or to the members of a "group" entity.
 
 Common uses of a policy include the following:
@@ -19,7 +19,7 @@ Common uses of a policy include the following:
 *	perform calculations,
 *	look up other values,
 *	invoke effectors  (management policies) or,
-*	cause the entity associated with the policy to emit sensor values (enricher policies). 
+*	cause the entity associated with the policy to emit sensor values (enricher policies).
 
 Entities can have zero or more ``Policy`` instances attached to them.
 
@@ -143,7 +143,7 @@ brooklyn.enrichers:
 - org.apache.brooklyn.enricher.stock.Propagator
 
 Use propagator to duplicate one sensor as another, giving the supplied sensor mapping.
-The other use of Propagator is where you specify a producer (using $brooklyn:entity(...) as below)
+The other use of Propagator is where you specify a producer (using `$brooklyn:entity(...)` as below)
 from which to take sensors; in that mode you can specify `propagate` as a list of sensors whose names are unchanged,
 instead of (or in addition to) this map
 
@@ -200,7 +200,7 @@ Converts absolute sensor values into a delta.
 - org.apache.brooklyn.enricher.stock.YamlTimeWeightedDeltaEnricher
 
 Converts absolute sensor values into a delta/second.
-	
+
 {% highlight yaml %}
 brooklyn.enrichers:
 - type: org.apache.brooklyn.enricher.stock.YamlTimeWeightedDeltaEnricher
@@ -215,7 +215,7 @@ brooklyn.enrichers:
 - org.apache.brooklyn.policy.enricher.RollingMeanEnricher
 
 Converts the last *N* sensor values into a mean.
-	
+
 ####	Rolling Time-window Mean
 
 - org.apache.brooklyn.policy.enricher.RollingTimeWindowMeanEnricher
@@ -235,6 +235,35 @@ An Enricher which computes latency in accessing a URL.
 Can be used to combine the values of sensors.  This enricher should be instantiated using Enrichers.buider.combining(..).
 This enricher is only available in Java blueprints and cannot be used in YAML.
 
+#### Note On Enricher Producers
+
+If an entity needs an enricher whose source sensor (`enricher.sourceSensor`) belongs to another entity, then the enricher
+configuration must include an `enricher.producer` key referring to the other entity.
+
+For example, if we consider the Transfomer from above, suppose that `enricher.sourceSensor: $brooklyn:sensor("urls.tcp.list")`
+is actually a sensor on a different entity called `load.balancer`. In this case, we would need to supply an
+`enricher.producer` value.
+
+{% highlight yaml %}
+brooklyn.enrichers:
+- type: org.apache.brooklyn.enricher.stock.Transformer
+  brooklyn.config:
+    enricher.producer: $brooklyn:entity("load.balancer")
+    enricher.sourceSensor: $brooklyn:sensor("urls.tcp.string")
+    enricher.targetSensor: $brooklyn:sensor("urls.tcp.withBrackets")
+    enricher.targetValue: |
+      $brooklyn:formatString("[%s]", $brooklyn:attributeWhenReady("urls.tcp.string"))
+{% endhighlight %}
+
+It is important to note that the value supplied to `enricher.producer` must be immediately resolvable. While it would be valid
+DSL syntax to write:
+
+{% highlight yaml %}
+enricher.producer: brooklyn:entity($brooklyn:attributeWhenReady("load.balancer.entity"))
+{% endhighlight %}
+
+(assuming the `load.balancer.entity` sensor returns a Brooklyn entity), this will not function properly because `enricher.producer`
+will unsuccessfully attempt to get the supplied entity immediately.
 
 Next: Writing a Policy
 ---------------------------


### PR DESCRIPTION
Adds documentation to address the problem described by https://issues.apache.org/jira/browse/BROOKLYN-458.

Questions for reviewers: 

* Should the "Enrichers" list be moved to its own page entirely, rather than being on the "Policies" page?
* Should the workaround listed in https://issues.apache.org/jira/browse/BROOKLYN-458?focusedCommentId=15938141&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15938141 be included in the docs?