### PR TITLE
Update jclouds 1.9.x links to point to jclouds 2.0.x

### DIFF
--- a/guide/ops/locations/_clouds.md
+++ b/guide/ops/locations/_clouds.md
@@ -236,7 +236,7 @@ template options for your cloud.
 
 Part of the process for creating a virtual machine is the creation of a jclouds `TemplateOptions` object. jclouds
 providers extends this with extra options for each cloud - so when using the AWS provider, the object will be of
-type `AWSEC2TemplateOptions`. By [examining the source code](https://github.com/jclouds/jclouds/blob/jclouds-1.9.0/providers/aws-ec2/src/main/java/org/jclouds/aws/ec2/compute/AWSEC2TemplateOptions.java),
+type `AWSEC2TemplateOptions`. By [examining the source code](https://jclouds.apache.org/reference/javadoc/2.0.x/org/jclouds/aws/ec2/compute/AWSEC2TemplateOptions.html),
 you can see all of the options available to you.
 
 The `templateOptions` config key takes a map. The keys to the map are method names, and Brooklyn will find the method on

--- a/guide/ops/locations/_openstack.md
+++ b/guide/ops/locations/_openstack.md
@@ -62,7 +62,7 @@ The default flavors are shown below (though the set of flavors can be
     +-----+-----------+-----------+------+
 
 For further configuration options, consult 
-[jclouds Nova template options](https://jclouds.apache.org/reference/javadoc/1.9.x/org/jclouds/openstack/nova/v2_0/compute/options/NovaTemplateOptions.html).
+[jclouds Nova template options](https://jclouds.apache.org/reference/javadoc/2.0.x/org/jclouds/openstack/nova/v2_0/compute/options/NovaTemplateOptions.html).
 These can be used with the **[templateOptions](#custom-template-options)** configuration option.
 
 
@@ -267,11 +267,3 @@ Note that the following values will be set by default when omitted above:
     jclouds.keystone.credential-type=passwordCredentials
     jclouds.openstack-nova.auto-generate-keypairs: true
     jclouds.openstack-nova.auto-create-floating-ips: true
-
-If you do not have `openstack-mitaka-nova`, you can build and install it using the following steps:
-
-* Generate a JAR `openstack-mitaka-nova-1.9.3-cloudsoft.20160831.jar`
-  by building: https://github.com/cloudsoft/jclouds-openstack-mitaka-nova
-* If using Karaf, install this bundle (e.g. `bundle:install mvn:io.cloudsoft.jclouds.api/openstack-mitaka-nova/1.9.3-cloudsoft.20160831`),
-  and start it (e.g. `bundle:start openstack-mitaka-nova`).
-* Or if using the old-style main, copy the jar into the `lib/patch` directory and retart.


### PR DESCRIPTION
Removed obsolete openstack-mitaka-nova section.