### PR TITLE
Recommend up to date JAVA_DEBUG_OPTS flags

### DIFF
--- a/guide/ops/osgi.md
+++ b/guide/ops/osgi.md
@@ -5,10 +5,8 @@ children:
 - osgi-configuration.md
 ---
 
-# Running Apache Brooklyn inside Karaf container
-
 The Apache Brooklyn Karaf based distribution lives in brooklyn-dist/karaf/apache-brooklyn folder.
-It's still in a testing stage so some features might not work as expected. Please contact us on the 
+Please contact us on the
 [mailing list](mailto:dev@brooklyn.apache.org) if you find any problems.
 
 ## Building
@@ -33,21 +31,6 @@ This will launch the [Karaf console](https://karaf.apache.org/manual/latest/user
 where you can interact with the running instance. Note that Brooklyn has already started at this point
 and is reachable at the usual web console url.
 
-To start in debug mode use
-
-{% highlight bash %}
-bin/karaf debug
-{% endhighlight %}
-
-and connect to port 5005 using your normal Java debugger.
-
-To pause startup until the debugger is connected you can use
-
-{% highlight bash %}
-JAVA_DEBUG_OPTS='-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005' bin/karaf debug
-{% endhighlight %}
-
-
 Start the instance as a server in the background using the following command
 
 {% highlight bash %}
@@ -57,7 +40,32 @@ bin/start
 The Karaf container will keep state such as installed bundles and configuration between restarts.
 To reset any changes add **clean** to the cli arguments.
 
+## Debugging
+
+To start in debug mode use
+
+{% highlight bash %}
+bin/karaf debug
+{% endhighlight %}
+
+and connect to port 5005 using your normal Java debugger.
+
+If you want to change dt_socket port you can pass `JAVA_DEBUG_PORT` environment variable
+
+{%highlight bash %}
+JAVA_DEBUG_PORT=5006 bin/karaf debug
+{% endhighlight %}
+
+To pause startup until the debugger is connected you can use
+
+{% highlight bash %}
+JAVA_DEBUG_OPTS='-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005' bin/karaf debug
+{% endhighlight %}
+
+For other options please check your JVM JPDA documentation.
+Hotspot JPDA:  https://docs.oracle.com/javase/8/docs/technotes/guides/jpda/
+
 ## Configuring
 
-Configuration of Brooklyn when running under Karaf is largely done through standard Karaf mechanisms. 
+Configuration of Brooklyn when running under Karaf is largely done through standard Karaf mechanisms.
 See the page on [OSGI Configuration](osgi-configuration.html) for details.


### PR DESCRIPTION
Put osgi mode debugging in separate section

Add JAVA_DEBUG_PORT description.

Recommend up to date JAVA_DEBUG_OPTS flags
Those are the same used with `bin/karaf debug`

---

-Xnoagent Ignored in Oracle Java
http://www.oracle.com/technetwork/java/javase/tech/faqs-jsp-142584.html#QC4

-Xnoagent Disables old JDB debugger in IBM Java
https://www.ibm.com/support/knowledgecenter/SSYKE2_7.0.0/com.ibm.java.zos.70.doc/diag/appendixes/cmdline/Xnoagent.html

Recommend using agentlib:jdwp over runjdwp:transport
The above is said to be deprecated in Java 6
http://docs.oracle.com/javase/6/docs/technotes/guides/jpda/conninv.html#Invocation
In Java 8 docs only agentlib:jdwp is mentioned

IBM also recommends using agentlib:jdwp
https://www.ibm.com/developerworks/opensource/library/os-eclipse-javadebug/index.html

Disable JIT compiler with -Xint instead of Djava.compiler=NONE
https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html
https://www.ibm.com/support/knowledgecenter/SSYKE2_7.1.0/com.ibm.java.lnx.71.doc/diag/appendixes/cmdline/xint.html
