### PR TITLE
Add “guide/locations” link to contents page

### DIFF
--- a/guide/index.md
+++ b/guide/index.md
@@ -9,6 +9,7 @@ children:
 - { path: /guide/misc/download.md }
 - { path: /guide/concepts/index.md }
 - { path: /guide/blueprints/index.md }
+- { path: /guide/locations/index.md }
 - { path: /guide/ops/index.md }
 - { path: /guide/misc/index.md }
 ---


### PR DESCRIPTION
Previously, there was no link to "locations" in the menu on the right, or at http://brooklyn.apache.org/v/latest/index.html

(However, there is already a link in the drop-down at the top for "Documentation", called "Deploying Blueprints". That name isn't consistent with "Locations" in the contents page, but I think we can live with that for now.)