### PR TITLE
Document `sshMonitoring.enabled`

### DIFF
--- a/guide/blueprints/example_yaml/vanilla-bash-netcat-file.yaml
+++ b/guide/blueprints/example_yaml/vanilla-bash-netcat-file.yaml
@@ -5,3 +5,6 @@ services:
   name: Simple Netcat Server
   brooklyn.config:
     download.url: file:///tmp/netcat-server.tgz
+    launch.command: |
+      ./start.sh &
+      echo $! > $PID_FILE

--- a/guide/blueprints/example_yaml/vanilla-bash-netcat-more-commands.yaml
+++ b/guide/blueprints/example_yaml/vanilla-bash-netcat-more-commands.yaml
@@ -12,6 +12,10 @@ services:
     # check-running and stop commands. These are optional; default behavior will "do the
     # right thing" with the pid file automatically.
 
-    shell.env:            { CHECK_MARKER: "checkRunning", STOP_MARKER: "stop" }
-    checkRunning.command: echo $CHECK_MARKER >> DATE && test -f "$PID_FILE" && ps -p `cat $PID_FILE` >/dev/null
-    stop.command:         echo $STOP_MARKER  >> DATE && test -f "$PID_FILE" && { kill -9 `cat $PID_FILE`; rm /tmp/vanilla.pid; }
+    shell.env:
+      CHECK_MARKER: "checkRunning"
+      STOP_MARKER: "stop"
+    checkRunning.command: |
+      echo $CHECK_MARKER >> DATE && test -f "$PID_FILE" && ps -p `cat $PID_FILE` >/dev/null
+    stop.command: |
+      echo $STOP_MARKER  >> DATE && test -f "$PID_FILE" && { kill -9 `cat $PID_FILE`; rm $PID_FILE; }


### PR DESCRIPTION
And some other tidies of custom-entities doc.

These docs are primarily for the change in https://github.com/apache/brooklyn-server/pull/824. It also documents how to wire up an alternative http-based polling for health.

IT also does some other tidy up. For example, `./start.sh` is no longer the default value for `launch.command` so we need to fix that example.