### PR TITLE
Update config keys' deprecated names

### DIFF
--- a/guide/blueprints/advanced-example.md
+++ b/guide/blueprints/advanced-example.md
@@ -197,7 +197,7 @@ certain conditions are met before continuing. For example:
 - type: kibana-standalone
   id: kibana
   name: Kibana Server
-  customize.latch: $brooklyn:component("es").attributeWhenReady("service.isUp")
+  latch.customize: $brooklyn:component("es").attributeWhenReady("service.isUp")
 ~~~
 
 This latch is used to stop Kibana customizing until the Elasticsearch cluster is up. We do this to ensure 
@@ -226,7 +226,7 @@ services:
         brooklyn.config:
           launch.command: sleep 2
           checkRunning.command: true
-          launch.latch: $brooklyn:parent().attributeWhenReady("single-executor")
+          latch.launch: $brooklyn:parent().attributeWhenReady("single-executor")
 ~~~
 
 It's important to note that the above setup is not reentrant. This means that users should be careful to

--- a/guide/blueprints/ansible/creating-ansible-blueprints.md
+++ b/guide/blueprints/ansible/creating-ansible-blueprints.md
@@ -151,7 +151,7 @@ There is no specific configuration in AnsibleEntity for Ansible [Roles](http://d
               - command: unzip -o -d /etc/ansible/playbooks /tmp/master.zip
     
       - serviceType: org.apache.brooklyn.entity.stock.BasicApplication
-        start.latch: $brooklyn:entity("bootstrap").attributeWhenReady("service.isUp")
+        latch.start: $brooklyn:entity("bootstrap").attributeWhenReady("service.isUp")
         brooklyn.children:
         - type: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
           name: test

--- a/guide/blueprints/example_yaml/brooklyn-elk-catalog.bom
+++ b/guide/blueprints/example_yaml/brooklyn-elk-catalog.bom
@@ -28,7 +28,7 @@ brooklyn.catalog:
       - type: kibana-standalone
         id: kibana
         name: Kibana Server
-        customize.latch: $brooklyn:component("es").attributeWhenReady("service.isUp")
+        latch.customize: $brooklyn:component("es").attributeWhenReady("service.isUp")
         brooklyn.config:
           kibana.elasticsearch.ip: $brooklyn:component("es").attributeWhenReady("host.address.first")
           kibana.elasticsearch.port: $brooklyn:component("es").config("elasticsearch.http.port")
@@ -47,7 +47,7 @@ brooklyn.catalog:
 
       - type: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
         id: tomcat
-        customize.latch: $brooklyn:entity("es").attributeWhenReady("service.isUp")
+        latch.customize: $brooklyn:entity("es").attributeWhenReady("service.isUp")
         brooklyn.config:
           wars.root: "http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war"
           children.startable.mode: background_late


### PR DESCRIPTION
Since Brooklyn 0.12.0 ([this PR](https://github.com/apache/brooklyn-server/pull/819) precisely) some config keys' name have been deprecated generated a warning when installing a blueprint using those. 

This fixes it by using the new names.