### PR TITLE
Add page title as part of the template rather than content

### DIFF
--- a/guide/_layouts/website/page.html
+++ b/guide/_layouts/website/page.html
@@ -8,3 +8,8 @@
     </header>
     {{ super() }}
 {% endblock %}
+
+{% block page %}
+<h1>{{page.title}}</h1>
+{{ super () }}
+{% endblock %}

--- a/guide/blueprints/advanced-example.md
+++ b/guide/blueprints/advanced-example.md
@@ -1,7 +1,6 @@
 ---
 title: YAML Blueprint Advanced Example
 ---
-# {{ page.title }}
 
 By this point you should be familiar with the fundamental concepts behind both Apache Brooklyn and YAML blueprints. This section of the documentation is intended to show a complete, advanced example of a YAML blueprint.
 

--- a/guide/blueprints/ansible/about-ansible.md
+++ b/guide/blueprints/ansible/about-ansible.md
@@ -1,7 +1,6 @@
 ---
 title: About Ansible
 ---
-# {{ page.title }}
 
 ## What you need to know about Ansible
 

--- a/guide/blueprints/ansible/creating-ansible-blueprints.md
+++ b/guide/blueprints/ansible/creating-ansible-blueprints.md
@@ -1,7 +1,6 @@
 ---
 title: Creating Blueprints with Ansible
 ---
-# {{ page.title }}
 
 To write a blueprint to use Ansible with Brooklyn it will help to have a degree of familiarity with Ansible itself. In the 
 sections below, when the Brooklyn configuration is described, the underlying Ansible operation is also noted briefly, for 

--- a/guide/blueprints/ansible/index.md
+++ b/guide/blueprints/ansible/index.md
@@ -2,7 +2,6 @@
 title: Ansible in YAML Blueprints
 partial-summary-depth: 1
 ---
-# {{ page.title }}
 
 This guide describes how Brooklyn entities can be created using the Ansible infrastructure management tool
  ([ansible.com](http://ansible.com)).

--- a/guide/blueprints/blueprinting-tips.md
+++ b/guide/blueprints/blueprinting-tips.md
@@ -1,7 +1,6 @@
 ---
 title: Blueprinting Tips
 ---
-# {{ page.title }}
 
 ## YAML Recommended
 

--- a/guide/blueprints/catalog/bundle.md
+++ b/guide/blueprints/catalog/bundle.md
@@ -1,7 +1,6 @@
 ---
 title: Bundling
 ---
-# {{ page.title }}
 
 ### Bundling Catalog Resources
 

--- a/guide/blueprints/catalog/cli.md
+++ b/guide/blueprints/catalog/cli.md
@@ -1,7 +1,6 @@
 ---
 title: Brooklyn Server Command Line Arguments
 ---
-# {{ page.title }}
 
 ### Brooklyn Server Command Line Arguments
 

--- a/guide/blueprints/catalog/index.md
+++ b/guide/blueprints/catalog/index.md
@@ -2,7 +2,6 @@
 title: Catalog
 partial-summary-depth: 1
 ---
-# {{ page.title }}
 
 Apache Brooklyn provides a **catalog**, which is a persisted collection of versioned blueprints 
 and other resources. A set of blueprints is loaded from the `default.catalog.bom` in the Brooklyn 

--- a/guide/blueprints/catalog/management.md
+++ b/guide/blueprints/catalog/management.md
@@ -1,7 +1,6 @@
 ---
 title: Catalog Management
 ---
-# {{ page.title }}
 
 ### Catalog Management
 

--- a/guide/blueprints/catalog/schema.md
+++ b/guide/blueprints/catalog/schema.md
@@ -1,7 +1,6 @@
 ---
 title: Catalog Items YAML Syntax
 ---
-# {{ page.title }}
 
 ### Catalog Items YAML Syntax
 

--- a/guide/blueprints/catalog/templates.md
+++ b/guide/blueprints/catalog/templates.md
@@ -1,7 +1,6 @@
 ---
 title: Templates and the Add-Application Wizard
 ---
-# {{ page.title }}
 
 ### Templates and the Add-Application Wizard
 

--- a/guide/blueprints/catalog/versioning.md
+++ b/guide/blueprints/catalog/versioning.md
@@ -1,7 +1,6 @@
 ---
 title: Versioning
 ---
-# {{ page.title }}
 
 Brooklyn supports multiple versions of a type to be installed and used at the same time.
 Versions are a first-class concept and are often prominently displayed in the UI.

--- a/guide/blueprints/chef/about-chef.md
+++ b/guide/blueprints/chef/about-chef.md
@@ -1,7 +1,6 @@
 ---
 title: About Chef
 ---
-# {{ page.title }}
 
 ## What you need to know about Chef
 

--- a/guide/blueprints/chef/advanced-chef-integration.md
+++ b/guide/blueprints/chef/advanced-chef-integration.md
@@ -1,7 +1,6 @@
 ---
 title: Advanced Chef Integration
 ---
-# {{ page.title }}
 
 ### Adding Sensors and Effectors
 

--- a/guide/blueprints/chef/creating-blueprints.md
+++ b/guide/blueprints/chef/creating-blueprints.md
@@ -1,7 +1,6 @@
 ---
 title: Creating Blueprints from Chef
 ---
-# {{ page.title }}
 
 In a nutshell, a new Chef-based entity can be defined as a service by specifying
 `chef:cookbook_name` as the `service_type`, along with a collection of optional configuration.

--- a/guide/blueprints/chef/index.md
+++ b/guide/blueprints/chef/index.md
@@ -2,7 +2,6 @@
 title: Chef in YAML Blueprints
 partial-summary-depth: 1
 ---
-# {{ page.title }}
 
 This guide describes how Brooklyn entities can be easily created from Chef cookbooks.
 As of this writing (May 2014) some of the integration points are under active development,

--- a/guide/blueprints/chef/writing-chef.md
+++ b/guide/blueprints/chef/writing-chef.md
@@ -1,7 +1,6 @@
 ---
 title: Writing Chef for Blueprints
 ---
-# {{ page.title }}
 
 ## Making it Simpler
 

--- a/guide/blueprints/clusters-and-policies.md
+++ b/guide/blueprints/clusters-and-policies.md
@@ -1,7 +1,6 @@
 ---
 title: Clusters and Policies
 ---
-# {{ page.title }}
 
 Now let's bring the concept of the "cluster" back in.
 We could wrap our appserver in the same `DynamicCluster` we used earlier,

--- a/guide/blueprints/clusters.md
+++ b/guide/blueprints/clusters.md
@@ -1,7 +1,6 @@
 ---
 title: Clusters, Specs, and Composition
 ---
-# {{ page.title }}
 
 What if you want multiple machines?
 

--- a/guide/blueprints/configuring-vms.md
+++ b/guide/blueprints/configuring-vms.md
@@ -1,7 +1,6 @@
 ---
 title: Configuring VMs
 ---
-# {{ page.title }}
 
 Another simple blueprint will just create a VM which you can use, without any software installed upon it:
 

--- a/guide/blueprints/creating-yaml.md
+++ b/guide/blueprints/creating-yaml.md
@@ -1,7 +1,6 @@
 ---
 title: The Basic Structure
 ---
-# {{ page.title }}
 
 ## A First Blueprint
 

--- a/guide/blueprints/custom-entities.md
+++ b/guide/blueprints/custom-entities.md
@@ -1,7 +1,6 @@
 ---
 title: Custom Entities
 ---
-# {{ page.title }}
 
 So far we've covered how to configure and compose entities.
 There's a large library of blueprints available, but

--- a/guide/blueprints/effectors.md
+++ b/guide/blueprints/effectors.md
@@ -1,7 +1,6 @@
 ---
 title: Effectors
 ---
-# {{ page.title }}
 
 Effectors perform an operation of some kind, carried out by a Brooklyn Entity.
 They can be manually invoked or triggered by a [Policy]({{book.path.docs}}/blueprints/policies.md).

--- a/guide/blueprints/enrichers.md
+++ b/guide/blueprints/enrichers.md
@@ -1,7 +1,6 @@
 ---
 title: Enrichers
 ---
-# {{ page.title }}
 
 Enrichers provide advanced manipulation of an entity's sensor values.
 See below for documentation of the stock enrichers available in Apache Brooklyn.

--- a/guide/blueprints/entity-configuration.md
+++ b/guide/blueprints/entity-configuration.md
@@ -1,7 +1,6 @@
 ---
 title: Entity Configuration
 ---
-# {{ page.title }}
 
 Within a blueprint or catalog item, entities can be configured. The rules for setting this 
 configuration, including when composing and extending existing entities, is described in this 

--- a/guide/blueprints/index.md
+++ b/guide/blueprints/index.md
@@ -2,4 +2,3 @@
 title: Writing Blueprints
 partial-summary-depth: 1
 ---
-# {{ page.title }}

--- a/guide/blueprints/java/archetype.md
+++ b/guide/blueprints/java/archetype.md
@@ -1,7 +1,6 @@
 ---
 title: Creating from a Maven Archetype
 ---
-# {{ page.title }}
 
 ### Maven Archetype
 

--- a/guide/blueprints/java/bundle-dependencies.md
+++ b/guide/blueprints/java/bundle-dependencies.md
@@ -1,7 +1,6 @@
 ---
 title: Handling Bundle Dependencies
 ---
-# {{ page.title }}
 
 Some Java blueprints will require third party libraries. These need to be made available to the
 Apache Brooklyn runtime. There are a number of ways this can be achieved.

--- a/guide/blueprints/java/common-usage.md
+++ b/guide/blueprints/java/common-usage.md
@@ -1,7 +1,6 @@
 ---
 title: Common Classes and Entities
 ---
-# {{ page.title }}
 
 <!-- TODO old, needs work (refactoring!) and use of java_link -->
 

--- a/guide/blueprints/java/defining-and-deploying.md
+++ b/guide/blueprints/java/defining-and-deploying.md
@@ -1,7 +1,6 @@
 ---
 title: Defining and Deploying
 ---
-# {{ page.title }}
 
 ## Intro
 

--- a/guide/blueprints/java/entities.md
+++ b/guide/blueprints/java/entities.md
@@ -1,7 +1,6 @@
 ---
 title: Custom Entity Development
 ---
-# {{ page.title }}
 
 This section details how to create new custom application components or groups as brooklyn entities.
 

--- a/guide/blueprints/java/entitlements.md
+++ b/guide/blueprints/java/entitlements.md
@@ -1,7 +1,6 @@
 ---
 title: Entitlements
 ---
-# {{ page.title }}
 
 Brooklyn supports a plug-in system for defining "entitlements" -- 
 essentially permissions.

--- a/guide/blueprints/java/entity.md
+++ b/guide/blueprints/java/entity.md
@@ -1,7 +1,6 @@
 ---
 title: Writing an Entity
 ---
-# {{ page.title }}
 
 ## Ways to write an entity
 

--- a/guide/blueprints/java/feeds.md
+++ b/guide/blueprints/java/feeds.md
@@ -1,7 +1,6 @@
 ---
 title: Feeds
 ---
-# {{ page.title }}
 
 <!-- TODO old, needs work (refactoring!) and use of java_link -->
 

--- a/guide/blueprints/java/index.md
+++ b/guide/blueprints/java/index.md
@@ -2,7 +2,6 @@
 title: Java Entities
 partial-summary-depth: 1
 ---
-# {{ page.title }}
 
 Java blueprints are powerful, but also rather more difficult to write than YAML.
 Advanced Java skills are required.

--- a/guide/blueprints/java/service-state.md
+++ b/guide/blueprints/java/service-state.md
@@ -1,7 +1,6 @@
 ---
 title: Service State
 ---
-# {{ page.title }}
 
 Any entity can use the standard "service-up" and "service-state" 
 sensors to inform other entities and the GUI about its status.

--- a/guide/blueprints/java/topology-dependencies.md
+++ b/guide/blueprints/java/topology-dependencies.md
@@ -1,7 +1,6 @@
 ---
 title: Topology, Dependencies, and Management Policies
 ---
-# {{ page.title }}
 
 Applications written in YAML can similarly be written in Java. However, the YAML approach is 
 recommended.

--- a/guide/blueprints/multiple-services.md
+++ b/guide/blueprints/multiple-services.md
@@ -1,7 +1,6 @@
 ---
 title: Multiple Services and Dependency Injection
 ---
-# {{ page.title }}
 
 We've seen the configuration of machines and how to build up clusters.
 Now let's return to our app-server example and explore how more interesting

--- a/guide/blueprints/policies.md
+++ b/guide/blueprints/policies.md
@@ -1,7 +1,6 @@
 ---
 title: Policies
 ---
-# {{ page.title }}
 
 Policies perform the active management enabled by Brooklyn.
 They can subscribe to entity sensors and be triggered by them (or they can run periodically,

--- a/guide/blueprints/salt/about-salt.md
+++ b/guide/blueprints/salt/about-salt.md
@@ -1,7 +1,6 @@
 ---
 title: About Salt
 ---
-# {{ page.title }}
 
 ## What you need to know about Salt
 

--- a/guide/blueprints/salt/creating-salt-blueprints.md
+++ b/guide/blueprints/salt/creating-salt-blueprints.md
@@ -1,7 +1,6 @@
 ---
 title: Creating Blueprints with Salt
 ---
-# {{ page.title }}
 
 To write a blueprint to use Salt with Brooklyn it will help to have a degree of familiarity with Salt itself. In the 
 sections below, when the Brooklyn configuration is described, the underlying Salt operation is also noted briefly, for 

--- a/guide/blueprints/salt/index.md
+++ b/guide/blueprints/salt/index.md
@@ -2,7 +2,6 @@
 title: Salt in YAML Blueprints
 partial-summary-depth: 1
 ---
-# {{ page.title }}
 
 This guide describes how Brooklyn entities can be created using the Salt infrastructure management tool
  ([saltstack.com](https://saltstack.com/)).

--- a/guide/blueprints/setting-locations.md
+++ b/guide/blueprints/setting-locations.md
@@ -1,7 +1,6 @@
 ---
 title: Setting Locations
 ---
-# {{ page.title }}
 
 Brooklyn supports a very wide range of target locations. 
 With deep integration to [Apache jclouds](https://jclouds.apache.org), most well-known clouds 

--- a/guide/blueprints/test/index.md
+++ b/guide/blueprints/test/index.md
@@ -2,7 +2,6 @@
 title: Testing YAML Blueprints
 partial-summary-depth: 1
 ---
-# {{ page.title }}
 
 Brooklyn provides a selection of test entities which can be used to validate Blueprints via YAML. The basic building block is a TargetableTestComponent, which is used to resolve a target. There are two different groups of entities that inherit from TargetableTestComponent. The first is structural, which effects how the tests are run, for example by affecting the order they are run in. The second group is validation, which is used to confirm the application is deployed as intended, for example by checking some sensor value.
 

--- a/guide/blueprints/test/test-entities.md
+++ b/guide/blueprints/test/test-entities.md
@@ -1,7 +1,6 @@
 ---
 title: Blueprint Test Entities
 ---
-# {{ page.title }}
 
 
 ## Structural Test Entities

--- a/guide/blueprints/test/usage-examples.md
+++ b/guide/blueprints/test/usage-examples.md
@@ -1,7 +1,6 @@
 ---
 title: Example Blueprint Tests
 ---
-# {{ page.title }}
 
 ## Introduction
 This section describes some simple tests based on the [Getting Started]({{book.path.docs}}/start/blueprints.md#launching-from-a-blueprint) example blueprint:

--- a/guide/blueprints/winrm/client.md
+++ b/guide/blueprints/winrm/client.md
@@ -1,7 +1,6 @@
 ---
 title: Winrm4j Client
 ---
-# {{ page.title }}
 
 ## Winrm4j parameters
 

--- a/guide/blueprints/winrm/index.md
+++ b/guide/blueprints/winrm/index.md
@@ -1,7 +1,6 @@
 ---
 title: Windows Blueprints
 ---
-# {{ page.title }}
 
 Brooklyn can deploy to Windows servers using WinRM to run commands. These deployments can be 
 expressed in pure YAML, and utilise Powershell to install and manage the software process. 

--- a/guide/blueprints/yaml-reference.md
+++ b/guide/blueprints/yaml-reference.md
@@ -1,7 +1,6 @@
 ---
 title: YAML Blueprint Reference
 ---
-# {{ page.title }}
 
 ## Root Elements
 

--- a/guide/concepts/application-parent-membership.md
+++ b/guide/concepts/application-parent-membership.md
@@ -1,7 +1,6 @@
 ---
 title: Application, Parent and Membership
 ---
-# {{ page.title }}
 
 All entities have a ***parent*** entity, which creates and manages it, with one important exception: *applications*.
 Application entities are the top-level entities created and managed externally, manually or programmatically.

--- a/guide/concepts/configuration-sensor-effectors.md
+++ b/guide/concepts/configuration-sensor-effectors.md
@@ -1,7 +1,6 @@
 ---
 title: Configuration, Sensors and Effectors
 ---
-# {{ page.title }}
 
 ### Configuration
 

--- a/guide/concepts/dependent-configuration.md
+++ b/guide/concepts/dependent-configuration.md
@@ -1,7 +1,6 @@
 ---
 title: Dependent Configuration
 ---
-# {{ page.title }}
 
 Under the covers Brooklyn has a sophisticated sensor event and subscription model, but conveniences around this model make it very simple to express cross-entity dependencies. Consider the example where Tomcat instances need to know the URL of a database (or a set of URLs to connect to a Monterey processing fabric, or other entities)
 

--- a/guide/concepts/entities.md
+++ b/guide/concepts/entities.md
@@ -1,7 +1,6 @@
 ---
 title: Entities
 ---
-# {{ page.title }}
 
 The central concept in a Brooklyn deployment is that of an ***entity***. 
 An entity represents a resource under management, either *base* entities (individual machines or software processes) 

--- a/guide/concepts/execution.md
+++ b/guide/concepts/execution.md
@@ -1,7 +1,6 @@
 ---
 title: Execution
 ---
-# {{ page.title }}
 
 All processing, whether an effector invocation or a policy cycle, are tracked as ***tasks***. This allows several important capabilities:
 

--- a/guide/concepts/index.md
+++ b/guide/concepts/index.md
@@ -2,7 +2,6 @@
 title: Brooklyn Concepts
 partial-summary-depth: 1
 ---
-# {{ page.title }}
 
 This introduces brooklyn and describes how it simplifies the deployment and management of big applications. It is
 intended for people who are using brooklyn-supported application components (such as web/app servers, data stores)

--- a/guide/concepts/lifecycle-managementcontext.md
+++ b/guide/concepts/lifecycle-managementcontext.md
@@ -1,7 +1,6 @@
 ---
 title: Lifecycle and ManagementContext
 ---
-# {{ page.title }}
 
 Under-the-covers, at heart of the brooklyn management plane is the ``ManagementContext``. 
 This is started automatically when using launching an application using the brooklyn CLI. For programmatic use, see 

--- a/guide/concepts/location.md
+++ b/guide/concepts/location.md
@@ -1,7 +1,6 @@
 ---
 title: Location
 ---
-# {{ page.title }}
 
 <!-- TODO, Clarify is how geographical location works.
 -->

--- a/guide/concepts/policies.md
+++ b/guide/concepts/policies.md
@@ -1,7 +1,6 @@
 ---
 title: Policies
 ---
-# {{ page.title }}
 
 Policies perform the active management enabled by Brooklyn. Entities can have zero or more ``Policy`` instances attached to them. 
 

--- a/guide/concepts/stop-start-restart-behaviour.md
+++ b/guide/concepts/stop-start-restart-behaviour.md
@@ -1,7 +1,6 @@
 ---
 title: Stop/start/restart behaviour
 ---
-# {{ page.title }}
 
 Many entities expose `start`, `stop` and `restart` effectors. The semantics of these operations (and the parameters they take) depends on the type of entity.
 

--- a/guide/dev/code/licensing.md
+++ b/guide/dev/code/licensing.md
@@ -1,7 +1,6 @@
 ---
 title: License Considerations
 ---
-# {{ page.title }}
 
 The Apache Software Foundation, quite rightly, place a high standard on code provenance and license compliance. The
 Apache license is flexible and compatible with many other types of license, meaning there is generally little problem

--- a/guide/dev/code/structure.md
+++ b/guide/dev/code/structure.md
@@ -1,7 +1,6 @@
 ---
 title: Code Structure
 ---
-# {{ page.title }}
 
 Brooklyn is split into the following subprojects:
 

--- a/guide/dev/code/tests.md
+++ b/guide/dev/code/tests.md
@@ -1,7 +1,6 @@
 ---
 title: Tests
 ---
-# {{ page.title }}
 
 We have the following tests groups:
 

--- a/guide/dev/env/ide/index.md
+++ b/guide/dev/env/ide/index.md
@@ -1,7 +1,6 @@
 ---
 title: IDE Setup
 ---
-# {{ page.title }}
 
 Gone are the days when IDE integration always just works...  Maven and Eclipse fight,
 neither quite gets along perfectly with Groovy,

--- a/guide/dev/env/maven-build.md
+++ b/guide/dev/env/maven-build.md
@@ -1,7 +1,6 @@
 ---
 title: Maven Build
 ---
-# {{ page.title }}
 
 ## The Basics
 

--- a/guide/dev/tips/debugging-remote-brooklyn.md
+++ b/guide/dev/tips/debugging-remote-brooklyn.md
@@ -1,7 +1,6 @@
 ---
 title: Brooklyn Remote Debugging
 ---
-# {{ page.title }}
 
 Usually during development, you will be running Brooklyn from your IDE (see [IDE Setup]({{book.path.docs}}/dev/env/ide/index.md)), in which case
 debugging is as simple as setting a breakpoint. There may however be times when you need to debug an existing remote

--- a/guide/dev/tips/index.md
+++ b/guide/dev/tips/index.md
@@ -1,7 +1,6 @@
 ---
 title: Miscellaneous Tips and Tricks
 ---
-# {{ page.title }}
 
 ## General Good Ways of Working
 

--- a/guide/dev/tips/logging.md
+++ b/guide/dev/tips/logging.md
@@ -1,7 +1,6 @@
 ---
 title: Logging
 ---
-# {{ page.title }}
 
 ## Logging: A Quick Overview
 

--- a/guide/locations/index.md
+++ b/guide/locations/index.md
@@ -1,7 +1,6 @@
 ---
 title: Locations
 ---
-# {{ page.title }}
 
 Locations are the environments to which Brooklyn deploys applications. Most commonly these 
 are cloud services such as AWS, GCE, and IBM Softlayer. Brooklyn also supports deploying 

--- a/guide/locations/provisioned-machine-requirements.md
+++ b/guide/locations/provisioned-machine-requirements.md
@@ -2,7 +2,6 @@
 title: Provisioned Machine Requirements
 layout: website-normal
 ---
-# {{ page.title }}
 
 The requirements for how a provisioned machine should behave will depend on the
 entites subsequently deployed there.

--- a/guide/misc/index.md
+++ b/guide/misc/index.md
@@ -2,7 +2,6 @@
 title: Other Resources
 partial-summary-depth: 1
 ---
-# {{ page.title }}
 
 {% if output.name == 'website' %}
 Further documentation specific to this version of Brooklyn includes:

--- a/guide/misc/release-notes.md
+++ b/guide/misc/release-notes.md
@@ -1,7 +1,6 @@
 ---
 title: Release Notes
 ---
-# {{ page.title }}
 
 ## Version {{ book.brooklyn_version }}
 

--- a/guide/ops/cli/cli-ref-guide.md
+++ b/guide/ops/cli/cli-ref-guide.md
@@ -1,7 +1,6 @@
 ---
 title: CLI Reference Guide
 ---
-# {{ page.title }}
 
 ## Usage
 ```text

--- a/guide/ops/cli/cli-usage-guide.md
+++ b/guide/ops/cli/cli-usage-guide.md
@@ -1,7 +1,6 @@
 ---
 title: CLI Usage Guide
 ---
-# {{ page.title }}
 
 This document provides a brief overview of using the most common Brooklyn CLI commands,
 by using the CLI to deploy an application then examine various aspects of it.

--- a/guide/ops/configuration/brooklyn_cfg.md
+++ b/guide/ops/configuration/brooklyn_cfg.md
@@ -1,7 +1,6 @@
 ---
 title: brooklyn.cfg
 ---
-# {{ page.title }}
 
 The file `brooklyn.cfg` is read when Apache Brooklyn starts in order to load any server configuration values. It can be found in the Brooklyn configuration folder. You can check [here]({{book.path.docs}}/ops/paths.md) for the location of your Brooklyn configuration folder
 

--- a/guide/ops/configuration/cors.md
+++ b/guide/ops/configuration/cors.md
@@ -1,7 +1,6 @@
 ---
 title: CORS Configuration
 ---
-# {{ page.title }}
 
 To enable / configure [cross-origin resource sharing (CORS)](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing).
 The following file must be added to [`org.apache.brooklyn.rest.filter.cors.cfg`]({{book.path.docs}}/ops/paths.md)

--- a/guide/ops/configuration/https.md
+++ b/guide/ops/configuration/https.md
@@ -1,7 +1,6 @@
 ---
 title: HTTPS Configuration
 ---
-# {{ page.title }}
 
 ## Getting the Certificate
 To enable HTTPS web access, you will need a server certificate in a java keystore. To create a self-signed certificate,

--- a/guide/ops/configuration/index.md
+++ b/guide/ops/configuration/index.md
@@ -2,7 +2,6 @@
 title: Brooklyn Configuration and Options
 partial-summary-depth: 1
 ---
-# {{ page.title }}
 
 Apache Brooklyn contains a number of configuration options managed across several files. 
 Historically Brooklyn has been configured through a brooklyn.properties file, this changed 

--- a/guide/ops/externalized-configuration.md
+++ b/guide/ops/externalized-configuration.md
@@ -1,7 +1,6 @@
 ---
 title: Externalized Configuration
 ---
-# {{ page.title }}
 
 Sometimes it is useful that configuration in a blueprint, or in Brooklyn itself, is not given explicitly, but is instead
 replaced with a reference to some other storage system. For example, it is undesirable for a blueprint to contain a

--- a/guide/ops/gui/blueprints.md
+++ b/guide/ops/gui/blueprints.md
@@ -1,7 +1,6 @@
 ---
 title: Deploying Blueprints
 ---
-# {{ page.title }}
 
 
 ## Launching from a Blueprint

--- a/guide/ops/gui/index.md
+++ b/guide/ops/gui/index.md
@@ -2,4 +2,3 @@
 title: GUI Guide
 partial-summary-depth: 1
 ---
-# {{ page.title }}

--- a/guide/ops/gui/managing.md
+++ b/guide/ops/gui/managing.md
@@ -1,7 +1,6 @@
 ---
 title: Monitoring and Managing Applications
 ---
-# {{ page.title }}
 
 From the Home page, click on the application name or open the Applications tab.
 

--- a/guide/ops/gui/policies.md
+++ b/guide/ops/gui/policies.md
@@ -1,7 +1,6 @@
 ---
 title: Using Policies
 ---
-# {{ page.title }}
 
 ## Exploring and Testing Policies
 

--- a/guide/ops/gui/running.md
+++ b/guide/ops/gui/running.md
@@ -1,7 +1,6 @@
 ---
 title: Launching
 ---
-# {{ page.title }}
 
 This guide will walk you through connecting to the Brooklyn Server Graphical User Interface and performing various tasks.
 

--- a/guide/ops/high-availability/high-availability-supplemental.md
+++ b/guide/ops/high-availability/high-availability-supplemental.md
@@ -1,7 +1,6 @@
 ---
 title: Configuring HA - an example
 ---
-# {{ page.title }}
 
 This supplements the [High Availability]({{book.path.docs}}/ops/high-availability/index.md) documentation
 and provides an example of how to configure a pair of Apache Brooklyn servers to run in master-standby mode with a shared NFS datastore

--- a/guide/ops/high-availability/index.md
+++ b/guide/ops/high-availability/index.md
@@ -1,7 +1,6 @@
 ---
 title: High Availability
 ---
-# {{ page.title }}
 
 Brooklyn will automatically run in HA mode if multiple Brooklyn instances are started
 pointing at the same persistence store.  One Brooklyn node (e.g. the first one started)

--- a/guide/ops/index.md
+++ b/guide/ops/index.md
@@ -2,4 +2,3 @@
 title: Reference Guide
 partial-summary-depth: 1
 ---
-# {{ page.title }}

--- a/guide/ops/logging.md
+++ b/guide/ops/logging.md
@@ -1,7 +1,6 @@
 ---
 title: Logging
 ---
-# {{ page.title }}
 
 Brooklyn uses the SLF4J logging facade, which allows use of many popular frameworks including `logback`, 
 `java.util.logging` and `log4j`.

--- a/guide/ops/persistence/index.md
+++ b/guide/ops/persistence/index.md
@@ -1,7 +1,6 @@
 ---
 title: Persistence
 ---
-# {{ page.title }}
 
 By default Brooklyn persists its state to storage so that a server can be restarted 
 without loss or so a high availability standby server can take over.

--- a/guide/ops/production-installation.md
+++ b/guide/ops/production-installation.md
@@ -1,7 +1,6 @@
 ---
 title: Production Installation
 ---
-# {{ page.title }}
 
 To install Apache Brooklyn on a production server:
 

--- a/guide/ops/requirements.md
+++ b/guide/ops/requirements.md
@@ -1,7 +1,6 @@
 ---
 title: Requirements
 ---
-# {{ page.title }}
 
 ## Server Specification
 

--- a/guide/ops/rest.md
+++ b/guide/ops/rest.md
@@ -1,7 +1,6 @@
 ---
 title: REST API
 ---
-# {{ page.title }}
 
 Apache Brooklyn exposes a powerful REST API, 
 allowing it to be scripted from bash or integrated with other systems.

--- a/guide/ops/security-guidelines.md
+++ b/guide/ops/security-guidelines.md
@@ -1,7 +1,6 @@
 ---
 title: Security Guidelines
 ---
-# {{ page.title }}
 
 ## Brooklyn Server
 

--- a/guide/ops/server-cli-reference.md
+++ b/guide/ops/server-cli-reference.md
@@ -1,7 +1,6 @@
 ---
 title: Server CLI Reference
 ---
-# {{ page.title }}
 
 **NOTE:** This document is for information on starting a Brooklyn Server.  For information on using the Brooklyn Client CLI to access an 
 already running Brooklyn Server, refer to [Client CLI Reference]({{book.path.docs}}/ops/cli/index.md).

--- a/guide/ops/starting-stopping-monitoring.md
+++ b/guide/ops/starting-stopping-monitoring.md
@@ -1,7 +1,6 @@
 ---
 title: Starting, Stopping and Monitoring
 ---
-# {{ page.title }}
 
 **NOTE:** This document is for information on starting an Apache Brooklyn
 Server.  For information on using the Brooklyn Client CLI to access an already

--- a/guide/ops/troubleshooting/connectivity.md
+++ b/guide/ops/troubleshooting/connectivity.md
@@ -1,7 +1,6 @@
 ---
 title: Troubleshooting Server Connectivity Issues in the Cloud
 ---
-# {{ page.title }}
 
 A common problem when setting up an application in the cloud is getting the basic connectivity right - how
 do I get my service (e.g. a TCP host:port) publicly accessible over the internet?

--- a/guide/ops/troubleshooting/deployment.md
+++ b/guide/ops/troubleshooting/deployment.md
@@ -1,7 +1,6 @@
 ---
 title: Troubleshooting Deployment
 ---
-# {{ page.title }}
 
 This guide describes common problems encountered when deploying applications.
 

--- a/guide/ops/troubleshooting/detailed-support-report.md
+++ b/guide/ops/troubleshooting/detailed-support-report.md
@@ -1,7 +1,6 @@
 ---
 title: Detailed Support Report
 ---
-# {{ page.title }}
 
 If you wish to send a detailed report, then depending on the nature of the problem, consider 
 collecting the following information.

--- a/guide/ops/troubleshooting/going-deep-in-java-and-logs.md
+++ b/guide/ops/troubleshooting/going-deep-in-java-and-logs.md
@@ -1,7 +1,6 @@
 ---
 title: "Troubleshooting: Going Deep in Java and Logs"
 ---
-# {{ page.title }}
 
 This guide takes a deep look at the Java and log messages for some failure scenarios,
 giving common steps used to identify the issues.

--- a/guide/ops/troubleshooting/increase-entropy.md
+++ b/guide/ops/troubleshooting/increase-entropy.md
@@ -1,7 +1,6 @@
 ---
 title: Increase Entropy
 ---
-# {{ page.title }}
 
 ### Checking entropy level
 

--- a/guide/ops/troubleshooting/increase-system-resource-limits.md
+++ b/guide/ops/troubleshooting/increase-system-resource-limits.md
@@ -1,7 +1,6 @@
 ---
 title: Increase System Resource Limits
 ---
-# {{ page.title }}
 
 If you encounter the following error:
 

--- a/guide/ops/troubleshooting/index.md
+++ b/guide/ops/troubleshooting/index.md
@@ -2,4 +2,3 @@
 title: Troubleshooting
 partial-summary-depth: 1
 ---
-# {{ page.title }}

--- a/guide/ops/troubleshooting/memory-usage.md
+++ b/guide/ops/troubleshooting/memory-usage.md
@@ -1,7 +1,6 @@
 ---
 title: "Troubleshooting: Monitoring Memory Usage"
 ---
-# {{ page.title }}
 
 ## Memory Usage
 

--- a/guide/ops/troubleshooting/overview.md
+++ b/guide/ops/troubleshooting/overview.md
@@ -1,7 +1,6 @@
 ---
 title: Troubleshooting Overview
 ---
-# {{ page.title }}
 
 This guide describes sources of information for understanding when things go wrong.
 

--- a/guide/ops/troubleshooting/slow-unresponsive.md
+++ b/guide/ops/troubleshooting/slow-unresponsive.md
@@ -1,7 +1,6 @@
 ---
 title: Brooklyn Slow or Unresponsive
 ---
-# {{ page.title }}
 
 There are many possible causes for a Brooklyn server becoming slow or unresponsive. This guide 
 describes some possible reasons, and some commands and tools that can help diagnose the problem.

--- a/guide/ops/troubleshooting/softwareprocess.md
+++ b/guide/ops/troubleshooting/softwareprocess.md
@@ -1,7 +1,6 @@
 ---
 title: Troubleshooting SoftwareProcess Entities
 ---
-# {{ page.title }}
 
 The [troubleshooting overview]({{book.path.docs}}/ops/troubleshooting/overview.md) in Brooklyn gives 
 information for how to find more information about errors.

--- a/guide/ops/troubleshooting/web-console-issues.md
+++ b/guide/ops/troubleshooting/web-console-issues.md
@@ -1,7 +1,6 @@
 ---
 title: Web Console Issues
 ---
-# {{ page.title }}
 
 ## Page Does Not Load in Chrome, Saying ""Waiting for available socket..."
 

--- a/guide/ops/upgrade.md
+++ b/guide/ops/upgrade.md
@@ -1,7 +1,6 @@
 ---
 title: Upgrade
 ---
-# {{ page.title }}
 
 This guide provides all necessary information to upgrade Apache Brooklyn for both the RPM/DEB and Tarball packages.
 

--- a/guide/start/blueprints.md
+++ b/guide/start/blueprints.md
@@ -1,7 +1,6 @@
 ---
 title: Deploying Blueprints
 ---
-# {{ page.title }}
 
 Blueprints are descriptors or patterns which describe how Apache Brooklyn should deploy applications. Blueprints are written in [YAML](https://en.wikipedia.org/wiki/YAML) and many of the entities available are defined in the __[Brooklyn Catalog]({{ book.url.brooklyn_website }}/learnmore/catalog/)__.
 

--- a/guide/start/concept-quickstart.md
+++ b/guide/start/concept-quickstart.md
@@ -1,7 +1,6 @@
 ---
 title: Brooklyn Concepts Quickstart
 ---
-# {{ page.title }}
 
 The following section provides a quick summary of the main Brooklyn concepts you will encounter in Getting Started.  For further discussion of these concepts see [The Theory Behind Brooklyn]({{book.url.brooklyn_website}}/learnmore/theory.html), and the detailed descriptions in [Brooklyn Concepts]({{book.path.docs}}/concepts/index.md).
 

--- a/guide/start/index.md
+++ b/guide/start/index.md
@@ -2,4 +2,3 @@
 title: Getting Started
 partial-summary-depth: 1
 ---
-# {{ page.title }}

--- a/guide/start/managing.md
+++ b/guide/start/managing.md
@@ -1,4 +1,3 @@
-# {{ page.title }}
 
 
 

--- a/guide/start/policies.md
+++ b/guide/start/policies.md
@@ -1,7 +1,6 @@
 ---
 title: Getting Started - Policies
 ---
-# {{ page.title }}
 
 ## A Clustered Example
 

--- a/guide/start/running.md
+++ b/guide/start/running.md
@@ -1,7 +1,6 @@
 ---
 title: Running Apache Brooklyn
 ---
-# {{ page.title }}
 
 This guide will walk you through deploying an example 3-tier web application to a public cloud, and demonstrate the autoscaling capabilities of the Brooklyn platform.
 


### PR DESCRIPTION
As the title said: rather than having the page title part of the markdown file, this pushes it into the template