### PR TITLE
Use colour from variables.less for blueprint tour

### DIFF
--- a/guide/styles/policy-tour.less
+++ b/guide/styles/policy-tour.less
@@ -131,7 +131,7 @@ div.annotated_blueprint div.code_scroller div.code_viewer div.block > div.annota
 }
 
 div.annotated_blueprint div.code_scroller div.code_viewer div.block:hover > div:last-child {
-  background-color: #48a648;
+  background-color: @accent-color;
   color: #fafafa;
 }
 
@@ -145,7 +145,7 @@ div.annotated_blueprint div.code_scroller div.code_viewer div.block:hover div.an
 
 div.annotated_blueprint div.code_scroller div.code_viewer div.block:hover div.annotations {
   background-color: #fafafa;
-  border: 4px solid #48a648;
+  border: 4px solid @accent-color;
   border-radius: 8px;
   text-align: center;
   box-shadow: 2px 10px 20px #aaa;
@@ -169,7 +169,7 @@ div.annotated_blueprint div.code_scroller div.code_viewer div.block:hover div.co
   width: 16px !important;
   border-width: 5px 0px 5px 6px;
   border-style: solid;
-  border-color: transparent transparent transparent #48a648;
+  border-color: transparent transparent transparent @accent-color;
 }
 
 div.annotated_blueprint div.code_scroller div.code_viewer div.block > div:last-child .ann_highlight {


### PR DESCRIPTION
The policies page example was not using the colour defined within the `variables.less` file, this fixes it.