### PR TITLE
Fix typo + syntax highlighting

### DIFF
--- a/guide/locations/_location-customizer-security-groups.md
+++ b/guide/locations/_location-customizer-security-groups.md
@@ -11,17 +11,18 @@ It is easy to add additional rules to the initial security group using `org.apac
 
 YAML Example:
 
-    name: ports @ AWS
-    location: jclouds:aws-ec2:us-west-2:
-    services:
-    - type: org.apache.brooklyn.entity.software.base.EmptySoftwareProcess
-      brooklyn.config:
-        provisioning.properties:
-          customizers:
-          - $brooklyn:object:
-              type: org.apache.brooklyn.location.jclouds.networking.SharedLocationSecurityGroupCustomizer
-              object.fields: {tcpPortRanges: ["900-910", "915", "22"], udpPortRanges: ["100","200-300"], cidr: "82.40.153.101/24"}
-
+```yaml
+name: ports @ AWS
+location: jclouds:aws-ec2:us-west-2
+services:
+- type: org.apache.brooklyn.entity.software.base.EmptySoftwareProcess
+  brooklyn.config:
+    provisioning.properties:
+      customizers:
+      - $brooklyn:object:
+          type: org.apache.brooklyn.location.jclouds.networking.SharedLocationSecurityGroupCustomizer
+          object.fields: {tcpPortRanges: ["900-910", "915", "22"], udpPortRanges: ["100","200-300"], cidr: "82.40.153.101/24"}
+```
 
 Make sure that you have rule which makes port 22 accessible from Apache Brooklyn.
 
@@ -31,11 +32,13 @@ Apache Brooklyn exposes the SharedLocationSecurityGroupCustomizer functionality 
 just by supplying `effector.add.openInboundPorts: true` "brooklyn.config".
 Example configuration in effector
 
-    location: jclouds:aws-ec2:us-west-2
-    services:
-    - type: org.apache.brooklyn.entity.software.base.EmptySoftwareProcess
-      brooklyn.config:
-        effector.add.openInboundPorts: true
+```yaml
+location: jclouds:aws-ec2:us-west-2
+services:
+- type: org.apache.brooklyn.entity.software.base.EmptySoftwareProcess
+  brooklyn.config:
+    effector.add.openInboundPorts: true
+```
 
 ### Known limitations
 


### PR DESCRIPTION
Fix typo in the first YAML example (`:` at the end of the location) + add syntax highlighting 