### PR TITLE
Update outdated blueprint examples

### DIFF
--- a/guide/blueprints/example_yaml/appserver-clustered-w-db-concise.yaml
+++ b/guide/blueprints/example_yaml/appserver-clustered-w-db-concise.yaml
@@ -3,7 +3,7 @@ services:
 - type: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
   brooklyn.config:
     cluster.initial.size: 2
-    wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+    wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
     http.port: 8080+
     java.sysprops: 
       brooklyn.example.db.url: $brooklyn:formatString("jdbc:%s%s?user=%s\\&password=%s", component("db").attributeWhenReady("datastore.url"), "visitors", "brooklyn", $brooklyn:external("brooklyn-demo-sample", "hidden-brooklyn-password"))

--- a/guide/blueprints/example_yaml/appserver-clustered-w-db.yaml
+++ b/guide/blueprints/example_yaml/appserver-clustered-w-db.yaml
@@ -7,7 +7,7 @@ services:
       $brooklyn:entitySpec:
         type: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
         brooklyn.config:
-          wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+          wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
           http.port: 8080+
           java.sysprops:
             brooklyn.example.db.url:

--- a/guide/blueprints/example_yaml/appserver-configured.yaml
+++ b/guide/blueprints/example_yaml/appserver-configured.yaml
@@ -2,5 +2,5 @@ name: appserver-configured
 services:
 - type: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
   brooklyn.config:
-    wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+    wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
     http.port: 8080

--- a/guide/blueprints/example_yaml/appserver-w-db-other-flavor.yaml
+++ b/guide/blueprints/example_yaml/appserver-w-db-other-flavor.yaml
@@ -3,7 +3,7 @@ services:
 - type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
   name: AppServer HelloWorld 
   brooklyn.config:
-    wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+    wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
     http.port: 8080+
     java.sysprops: 
       brooklyn.example.db.url:

--- a/guide/blueprints/example_yaml/appserver-w-db.yaml
+++ b/guide/blueprints/example_yaml/appserver-w-db.yaml
@@ -3,7 +3,7 @@ services:
 - type: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
   name: AppServer HelloWorld 
   brooklyn.config:
-    wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+    wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
     http.port: 8080+
     java.sysprops: 
       brooklyn.example.db.url:

--- a/guide/blueprints/example_yaml/appserver-w-policy.yaml
+++ b/guide/blueprints/example_yaml/appserver-w-policy.yaml
@@ -7,7 +7,7 @@ services:
       $brooklyn:entitySpec:
         type: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
         brooklyn.config:
-          wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+          wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
           http.port: 8080+
           java.sysprops:
             brooklyn.example.db.url:

--- a/guide/blueprints/example_yaml/brooklyn-elk-catalog.bom
+++ b/guide/blueprints/example_yaml/brooklyn-elk-catalog.bom
@@ -49,7 +49,7 @@ brooklyn.catalog:
         id: tomcat
         latch.customize: $brooklyn:entity("es").attributeWhenReady("service.isUp")
         brooklyn.config:
-          wars.root: "http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war"
+          wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
           children.startable.mode: background_late
 
         provisioning.properties:

--- a/guide/blueprints/test/example_yaml/entities/testeffector-entity.yaml
+++ b/guide/blueprints/test/example_yaml/entities/testeffector-entity.yaml
@@ -5,5 +5,5 @@
     effector: deploy
     timeout: 5m
     params:
-      url: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+      url: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
       targetName: newcontext

--- a/guide/blueprints/test/example_yaml/testcases/effector-test-snippet.yaml
+++ b/guide/blueprints/test/example_yaml/testcases/effector-test-snippet.yaml
@@ -16,7 +16,7 @@
       effector: deploy
       timeout: 5m
       params:
-        url: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+        url: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
         targetName: newcontext
   - type: org.apache.brooklyn.test.framework.TestHttpCall
     name: Check Deployed Webapp Status Code

--- a/guide/blueprints/test/example_yaml/testcases/getting-started-test-example.yaml
+++ b/guide/blueprints/test/example_yaml/testcases/getting-started-test-example.yaml
@@ -10,7 +10,7 @@ services:
   name: My Web
   id: webappcluster
   brooklyn.config:
-    wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+    wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
     java.sysprops:
       brooklyn.example.db.url: >
         $brooklyn:formatString("jdbc:%s%s?user=%s&password=%s",
@@ -62,7 +62,7 @@ services:
       effector: deploy
       timeout: 5m
       params:
-        url: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+        url: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
         targetName: newcontext
   - type: org.apache.brooklyn.test.framework.TestHttpCall
     name: Check Deployed Webapp Status Code

--- a/guide/blueprints/test/usage-examples.md
+++ b/guide/blueprints/test/usage-examples.md
@@ -19,14 +19,6 @@ Demonstrates the following sensor assertion:
 
 !CODEFILE "example_yaml/testcases/sensor-test-snippet.yaml"
 
-### HTTP Call Tests
-Demonstrates the following HTTP Call assertions against the specified `url`, which in these examples are being built from the `webappcluster` entities `host.address` and `proxy.http.port` sensors (the tester having flexibility in how the test URL is to be constructed):
-
-- asserts the response status code is 200 within 10 minutes of the blueprint being deployed.
-- asserts the response body matches the regex `(?s).*Br[o]{2}klyn Deployed.*` within 10 minutes of the blueprint being deployed. Note the presence of the `(?s)` dotall flag to test a multiline response.
-
-!CODEFILE "example_yaml/testcases/http-test-snippet.yaml"
-
 ### Effector Test (via TestCase entity)
 
 This `TestEffector` example demonstrates the use of the `TestCase` and `TestSensor` entities to ensure the service has started before invoking an effector using the `TestEffector` entity.
@@ -37,6 +29,14 @@ This `TestEffector` example demonstrates the use of the `TestCase` and `TestSens
   - asserts `/newcontext` url returns a HTTP status code 200 within 5 minutes of the effector being invoked (Note that this timeout is relative to the preceding test entity as they are being sequentially run as children of a `TestCase` entity).
 
 !CODEFILE "example_yaml/testcases/effector-test-snippet.yaml"
+
+### HTTP Call Tests
+Demonstrates the following HTTP Call assertions against the specified `url`, which in these examples are being built from the `webappcluster` entities `host.address` and `proxy.http.port` sensors (the tester having flexibility in how the test URL is to be constructed):
+
+- asserts the response status code is 200 within 10 minutes of the blueprint being deployed.
+- asserts the response body matches the regex `(?s).*Br[o]{2}klyn Deployed.*` within 10 minutes of the blueprint being deployed. Note the presence of the `(?s)` dotall flag to test a multiline response.
+
+!CODEFILE "example_yaml/testcases/http-test-snippet.yaml"
 
 ### Full Example
 A sample blueprint containing all the tests described above is available [here](./example_yaml/testcases/getting-started-test-example.yaml).

--- a/guide/ops/gui/_my-web-cluster.yaml
+++ b/guide/ops/gui/_my-web-cluster.yaml
@@ -10,7 +10,7 @@ services:
   name: My Web
   id: webappcluster
   brooklyn.config:
-    wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+    wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
     java.sysprops:
       brooklyn.example.db.url: >
         $brooklyn:formatString("jdbc:%s%s?user=%s&password=%s",

--- a/guide/ops/gui/_my-web-cluster2.yaml
+++ b/guide/ops/gui/_my-web-cluster2.yaml
@@ -7,7 +7,7 @@ services:
 - type: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
   name: My Web
   brooklyn.config:
-    wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+    wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
     java.sysprops:
       brooklyn.example.db.url: >
         $brooklyn:formatString("jdbc:%s%s?user=%s&password=%s",

--- a/guide/start/_my-web-cluster.yaml
+++ b/guide/start/_my-web-cluster.yaml
@@ -10,7 +10,7 @@ services:
   name: My Web
   id: webappcluster
   brooklyn.config:
-    wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+    wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
     java.sysprops:
       brooklyn.example.db.url: >
         $brooklyn:formatString("jdbc:%s%s?user=%s&password=%s",

--- a/guide/start/_my-web-cluster2.yaml
+++ b/guide/start/_my-web-cluster2.yaml
@@ -7,7 +7,7 @@ services:
 - type: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
   name: My Web
   brooklyn.config:
-    wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.8.0-incubating/brooklyn-example-hello-world-sql-webapp-0.8.0-incubating.war
+    wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-sql-webapp/0.12.0/brooklyn-example-hello-world-sql-webapp-0.12.0.war # BROOKLYN_VERSION
     java.sysprops:
       brooklyn.example.db.url: >
         $brooklyn:formatString("jdbc:%s%s?user=%s&password=%s",

--- a/guide/start/example_yaml/mycluster.yaml
+++ b/guide/start/example_yaml/mycluster.yaml
@@ -21,7 +21,7 @@ services:
         type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
         name: Tomcat Server
         brooklyn.config:
-          wars.root: http://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-webapp/0.8.0-incubating/brooklyn-example-hello-world-webapp-0.8.0-incubating.war
+          wars.root: https://search.maven.org/remotecontent?filepath=org/apache/brooklyn/example/brooklyn-example-hello-world-webapp/0.12.0/brooklyn-example-hello-world-webapp-0.12.0.war # BROOKLYN_VERSION
  
         brooklyn.policies:
         - type: org.apache.brooklyn.policy.ha.ServiceRestarter


### PR DESCRIPTION
This update URL to the newest version of example wars, within example blueprints. It also adds `# BROOKLYN_VERSION` tag so that links can be updated when new version of the documentation is published.