### PR TITLE
Update YAML example to newer syntax

### DIFF
--- a/guide/blueprints/ansible/creating-ansible-blueprints.md
+++ b/guide/blueprints/ansible/creating-ansible-blueprints.md
@@ -126,44 +126,45 @@ There is no specific configuration in AnsibleEntity for Ansible [Roles](http://d
  AnsibleEntity might require.  The second child uses `attributeWhenReady` to block until the first is ready, before 
  starting the AnsibleEntity to apply the desired playbook.
  
+```yaml
+name: multi
+location:
+  red1
+services:
+- type: brooklyn.entity.basic.SameServerEntity
+  name: Entities
+  brooklyn.children:
+  
+  - type: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
+    id: bootstrap
+    service.name: crond
+    playbook: bootstrap
+    playbook.yaml: |
+        ---
+        - hosts: localhost
+          tasks:
+          - shell: printf "[tomcat-servers]\nlocalhost ansible_connection=local\n" >> /etc/ansible/hosts
+          - file: path=/etc/ansible/playbooks state=directory mode=0755
+          - get_url: url=https://github.com/ansible/ansible-examples/archive/master.zip dest=/tmp/master.zip mode=0440
+          - command: unzip -o -d /etc/ansible/playbooks /tmp/master.zip
 
-    name: multi
-    location:
-      red1
-    services:
-    - serviceType: brooklyn.entity.basic.SameServerEntity
-      name: Entities
-      brooklyn.children:
-      
-      - serviceType: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
-        id: bootstrap
-        service.name: crond
-        playbook: bootstrap
-        playbook.yaml: |
-            ---
-            - hosts: localhost
-              tasks:
-              - shell: printf "[tomcat-servers]\nlocalhost ansible_connection=local\n" >> /etc/ansible/hosts
-              - file: path=/etc/ansible/playbooks state=directory mode=0755
-              - get_url: url=https://github.com/ansible/ansible-examples/archive/master.zip dest=/tmp/master.zip mode=0440
-              - command: unzip -o -d /etc/ansible/playbooks /tmp/master.zip
-    
-      - serviceType: org.apache.brooklyn.entity.stock.BasicApplication
-        latch.start: $brooklyn:entity("bootstrap").attributeWhenReady("service.isUp")
-        brooklyn.children:
-        - type: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
-          name: test
-          service.name: tomcat
-          playbook: tomcat
-          playbook.yaml: |
-              ---
-              - hosts: localhost
-              - include: /etc/ansible/playbooks/ansible-examples-master/tomcat-standalone/site.yml
-                vars:
-                    http_port: 8080
-                    https_port: 8443
-                    admin_username: admin
-                    admin_password: secret
+  - type: org.apache.brooklyn.entity.stock.BasicApplication
+    latch.start: $brooklyn:entity("bootstrap").attributeWhenReady("service.isUp")
+    brooklyn.children:
+    - type: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
+      name: test
+      service.name: tomcat
+      playbook: tomcat
+      playbook.yaml: |
+          ---
+          - hosts: localhost
+          - include: /etc/ansible/playbooks/ansible-examples-master/tomcat-standalone/site.yml
+            vars:
+                http_port: 8080
+                https_port: 8443
+                admin_username: admin
+                admin_password: secret
+```
 
  
 An alternative to the above is to use Ansible itself to do the waiting, as in the variant below, which uses AnsibleEntity
@@ -171,41 +172,42 @@ itself in the first SameServerEntity child, to install the required material.  I
 AnsibleEntity rather than a BasicApplication, Ansible's `wait_for` operation is used as the first step in the playbook, 
 to block the remaining steps in its playbook until the first is complete.
 
-    name: multi
-    location:
-      red1
-    services:
-    - serviceType: brooklyn.entity.basic.SameServerEntity
-      name: Entities
-      brooklyn.children:
-      
-      - serviceType: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
-        id: bootstrap
-        service.name: crond
-        playbook: bootstrap
-        playbook.yaml: |
-            ---
-            - hosts: localhost
-              tasks:
-              - command: rm -f /tmp/bootstrap.done
-              - shell: printf "[tomcat-servers]\nlocalhost ansible_connection=local\n" >> /etc/ansible/hosts
-              - file: path=/etc/ansible/playbooks state=directory mode=0755
-              - get_url: url=https://github.com/ansible/ansible-examples/archive/master.zip dest=/tmp/master.zip mode=0440
-              - command: unzip -o -d /etc/ansible/playbooks /tmp/master.zip
-              - file: path=/tmp/bootstrap.done state=touch
-    
-      - serviceType: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
-        name: test
-        service.name: tomcat
-        playbook: tomcat
-        playbook.yaml: |
-            ---
-            - tasks:
-              - wait_for: path=/tmp/bootstrap.done
-              include: /etc/ansible/playbooks/ansible-examples-master/tomcat-standalone/site.yml
-              vars:
-                http_port: 8080
-                https_port: 8443
-                admin_username: admin
-                admin_password: secret
+```yaml
+name: multi
+location:
+  red1
+services:
+- type: brooklyn.entity.basic.SameServerEntity
+  name: Entities
+  brooklyn.children:
+  
+  - type: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
+    id: bootstrap
+    service.name: crond
+    playbook: bootstrap
+    playbook.yaml: |
+        ---
+        - hosts: localhost
+          tasks:
+          - command: rm -f /tmp/bootstrap.done
+          - shell: printf "[tomcat-servers]\nlocalhost ansible_connection=local\n" >> /etc/ansible/hosts
+          - file: path=/etc/ansible/playbooks state=directory mode=0755
+          - get_url: url=https://github.com/ansible/ansible-examples/archive/master.zip dest=/tmp/master.zip mode=0440
+          - command: unzip -o -d /etc/ansible/playbooks /tmp/master.zip
+          - file: path=/tmp/bootstrap.done state=touch
 
+  - type: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
+    name: test
+    service.name: tomcat
+    playbook: tomcat
+    playbook.yaml: |
+        ---
+        - tasks:
+          - wait_for: path=/tmp/bootstrap.done
+          include: /etc/ansible/playbooks/ansible-examples-master/tomcat-standalone/site.yml
+          vars:
+            http_port: 8080
+            https_port: 8443
+            admin_username: admin
+            admin_password: secret
+ ```


### PR DESCRIPTION
Does 3 things:
- update `serviceType` to `type`
- update `start.latch` to `latch.start`
- use backticks to have syntax highlighting on YAML examples