### PR TITLE
Quote included file name

### DIFF
--- a/guide/blueprints/policies.md
+++ b/guide/blueprints/policies.md
@@ -109,7 +109,7 @@ The ConnectionFailureDetector is an HA policy for monitoring an http connection,
 
 ### Primary Election / Failover Policies
 
-{% include _elect-primary-policies.md %}
+{% include '_elect-primary-policies.md' %}
 
 
 ### Optimization Policies


### PR DESCRIPTION
Without the quotes `npm run book` fails cryptically: "template names must be a string: NaN"