### PR TITLE
Add page with information about GSoC 2018

### DIFF
--- a/community/gsoc.md
+++ b/community/gsoc.md
@@ -1,0 +1,58 @@
+---
+layout: website-normal
+title: Google Summer of Code
+---
+
+<div class="panel panel-default">
+  <div class="panel-heading" markdown="1">
+#### Current Status
+  </div>
+  <div class="panel-body" markdown="1">
+The Apache Software Foundation is participating in 2018's Google Summer of Code!
+Apache Brooklyn, along with our fellow projects at the ASF, are welcoming
+contact from potential GSoC students. You are welcome to work on your own ideas
+for our project, or look at the [list of project ideas](http://s.apache.org/gsoc2018ideas)
+(note that this list is for *all* of the Foundation's projects, not just
+Brooklyn.)
+
+Applications open on **March 12th 2018** and must be received by **March 27th
+2018**. It will greatly benefit your application if you join our community and
+discuss your proposals with us before you make your application - see below for
+more details.
+  </div>
+</div>
+
+## Potential students
+
+Thank you for considering Apache Brooklyn and The Apache Software Foundation for
+your GSoC project. Welcome to our community!
+
+Firstly, if you have not already done so, please read the [Student Guide to
+Google Summer of Code](https://google.github.io/gsocguides/student/). It
+contains essential information about how to approach your project before and
+after your application is submitted. Also, please read the [GSoC information
+provided by The Apache Software Foundation](https://community.apache.org/gsoc.html).
+
+Secondly, Apache values community, and the community and all its work is done in
+the open, on public mailing lists and IRC channels. Please [subscribe to our
+mailing lists](mailing-lists.html) and optionally [join our IRC channel](irc.html).
+You can also [read our list archives](https://lists.apache.org/list.html?dev@brooklyn.apache.org)
+to see what we've discussed in the past. Observe how we do things, and then
+please jump in and introduce yourself and your ideas for our project. The
+["Making First Contact" page of the GSoC Student Guide](https://google.github.io/gsocguides/student/making-first-contact)
+will guide you here.
+
+We, the Apache Brooklyn community, would be interested in hearing your ideas for
+what and how you would like to do with your GSoC project for Brooklyn. Whilst we
+have given some ideas for *what* we would like our GSoC projects to be about, we
+have deliberately left the *how* up to you. Please use the mailing list to ask
+questions, make suggestions, and "sound out" potential solutions that meet the
+requirements. Such discussions will be valuable to you when you come to make
+your formal project proposal.
+
+We recommend against emailing project individuals directly - Apache prefers to
+communicate in the open as much as possible, therefore you should direct your
+emails to the public mailing list. If you have any questions which you would
+prefer to ask privately, please email the project's private address at
+[private@brooklyn.apache.org](mailto:private@brooklyn.apache.org).
+

--- a/community/index.md
+++ b/community/index.md
@@ -7,6 +7,7 @@ children:
 - security/index.md
 - { link: 'https://issues.apache.org/jira/browse/BROOKLYN', title: 'Bug Tracker (JIRA)' }
 - { path: how-to-contribute-docs.md }
+- gsoc.md
 ---
 
 <div class="row">


### PR DESCRIPTION
Add a page to the "Community" section which describes Google Summer of Code 2018, and answers some frequently asked questions.