### PR TITLE
Add ApacheCon logo button to landing page

### DIFF
--- a/_includes/apache-promo.html
+++ b/_includes/apache-promo.html
@@ -1,0 +1,3 @@
+<a  href="https://www.apache.org/events/current-event.html">
+    <img src="https://www.apache.org/events/current-event-234x60.png"/>
+</a>

--- a/index.md
+++ b/index.md
@@ -71,6 +71,8 @@ children:
 ---
 
 <section class="text-center hero" markdown="1">
+{% include apache-promo.html %}
+
 
 # <span class="text-apache">apache</span> <span class="text-brooklyn">brooklyn</span>
 


### PR DESCRIPTION
As requested by Rich Bowen:

On Mon, 9 Apr 2018 at 14:07 Rich Bowen <rbowen@apache.org> wrote:
Dear PMCs,

ApacheCon is our official community event, and is coming up in
September, in Montreal. We need your help getting the word out to your
user communities. (Details at http://apachecon.com/ )

We've made this as easy as possible - it's just a cut-and-paste
snippet that we ask you to add to your site to display the logo of the
nearest future event. That process is documented here:
http://apache.org/events/README.txt  You can see it in action on, for
example, http://httpd.apache.org/

If you follow these steps, it will automatically update for the next
event, and the one after that. We have two other events planned for
this year, and are already working on 5 events for 2019.

Note: If you don't like the available image sizes, please pitch in and
help us define better sizes/dimensions. Patches welcome. We also have
these banners - http://apachecon.com/acna18/banners/ - which can be
used instead, and can also be used for other, non-ASF sites.

This is also a good time to remind you that we have general site
requirements. These are outlined at
https://www.apache.org/foundation/marks/pmcs#navigation and you can
check your project's compliance at https://whimsy.apache.org/site/

Thanks, and don't hesitate to get in touch if you have any questions,
comments, or concerns.

Rich Bowen, VP, Events




This looks like:

<img width="1283" alt="screen shot 2018-04-11 at 21 55 09" src="https://user-images.githubusercontent.com/14142759/38642985-a8c5a5c8-3dd3-11e8-9841-b36bc8face03.png">
