### PR TITLE
Fix copy-state usage for brooklyn-karaf

### DIFF
--- a/guide/ops/persistence/index.md
+++ b/guide/ops/persistence/index.md
@@ -246,16 +246,16 @@ The state can be downloaded periodically from the object store, archived and bac
 An example script to be invoked by CRON is shown below:
 
     DATE=`date "+%Y%m%d.%H%M.%S"`
-    BACKUP_FILENAME=/path/to/archives/back-${DATE}.tar.gz
-    TEMP_DATA_DIR=/path/to/tempdir
-    
-    brooklyn copy-state \
-            --persistenceLocation named:my-persistence-location \
-            --persistenceDir /path/to/bucket \
-            --destinationDir $TEMP_DATA_DIR
+    BACKUP_FILENAME=/path/to/archives/back-${DATE}.zip
+    HOSTNAME=localhost
+    USERNAME=admin
+    PASSWORD=pa55wOrd
 
-    tar --exclude '*/backups/*' -czvf $BACKUP_FILENAME $TEMP_DATA_DIR
+    curl -v -u "${USERNAME}:${PASSWORD}" \
+            https://${HOSTNAME}:8443/v1/server/ha/persist/export \
+            > ${BACKUP_FILENAME}
+
     # For s3cmd installation see http://s3tools.org/repositories
     s3cmd put $BACKUP_FILENAME s3://mybackupbucket
     rm $BACKUP_FILENAME
-    rm -r $TEMP_DATA_DIR
+


### PR DESCRIPTION
In brooklyn classic, one could run `brooklyn copy-state ...`. This is not supported in brooklyn karaf.

Instead, the REST api can be used. This PR updates the docs to show how to use it.

Please first review/merge https://github.com/apache/brooklyn-server/pull/972, to fix this REST api for usage in karaf!