### PR TITLE
Replace underscores with spaces to produce hard line break

### DIFF
--- a/guide/blueprints/java/bundle-dependencies.md
+++ b/guide/blueprints/java/bundle-dependencies.md
@@ -128,7 +128,7 @@ there are a few options for getting an equivalent OSGi bundle:
 * Use the `wrap:` prefix. The [PAX URL Wrap protocol](https://ops4j1.jira.com/wiki/display/paxurl/Wrap+Protocol) 
   is an OSGi URL handler that can process your legacy jar at runtime and transform it into an OSGi bundle.  
   This can be used when declaring a dependency in your feature.xml, and when using the Karaf console's
-  `bundle:install`. Note that it is not yet supported in Brooklyn's `brooklyn.libraries` catalog items.__
+  `bundle:install`. Note that it is not yet supported in Brooklyn's `brooklyn.libraries` catalog items.  
   When using `wrap:` include the `Bundle-SymbolicName` and `Bundle-Version` headers as parameters. (e.g.
   `wrap:mvn:javax.xml.ws/jaxws-api/2.3.0$Bundle-Symbolic-Name=javax.xml.ws.api&amp;Bundle-Version=2.3.0`)
 


### PR DESCRIPTION
@ahgittin Fix for my not seeing the difference between my editor highlighting trailing spaces and real underscores.