### PR TITLE
Add text to comply with Apache naming guidelines

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,3 +96,9 @@ DEPENDENCIES
   jekyll
   json
   therubyracer
+
+RUBY VERSION
+   ruby 2.1.2p95
+
+BUNDLED WITH
+   1.16.6

--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ Some issues we've encountered are:
  * if `libxml2` fails, set `bundle config build.nokogiri --use-system-libraries` before the install
    (more details [here](http://www.nokogiri.org/tutorials/installing_nokogiri.html))
  * on Ubuntu, `sudo apt-get install libxslt-dev libxml2-dev libcurl4-openssl-dev python-minimal`
+ * if you run into problems with 
+    ```
+    Could not load OpenSSL.
+    You must recompile Ruby with OpenSSL support or change the sources in your Gemfile from 'https' to 'http'. Instructions for compiling with OpenSSL using RVM are
+    available at rvm.io/packages/openssl.
+    ```
+ * then try 
+    ```
+    rvm reinstall 2.1.2 --with-opt-dir=/usr/local --with-openssl-dir=/usr/local/opt/openssl
+    ```
+
+ * if you run into trouble with therubyracer and v8 then try (from [link](https://stackoverflow.com/questions/19673714/error-installing-libv8-error-failed-to-build-gem-native-extension))
+    ```
+    $ gem install libv8 -v '3.16.14.7' -- --with-system-v8
+    $ bundle install
+    $ gem uninstall libv8
+    $ brew install v8
+    $ gem install therubyracer
+    $ bundle install
+    $ gem install libv8 -v '3.16.14.7' -- --with-system-v8
+    $ bundle install
+    ```
 
 Seeing the Website and Docs
 ---------------------------

--- a/download/index.md
+++ b/download/index.md
@@ -8,8 +8,9 @@ children:
 - ../meta/versions.md
 ---
 
-### Apache Brooklyn is software for modelling, monitoring and managing cloud applications through autonomic blueprints.
-
+<h4>
+ Apache Brooklyn is software for modelling, monitoring and managing cloud applications through autonomic blueprints.
+</h4>
 
 <div class="row">
 

--- a/download/index.md
+++ b/download/index.md
@@ -8,9 +8,9 @@ children:
 - ../meta/versions.md
 ---
 
-<h4>
- Apache Brooklyn is software for modelling, monitoring and managing cloud applications through autonomic blueprints.
-</h4>
+<h5>
+ Apache Brooklyn is software for modelling, deploying and managing cloud applications through autonomic blueprints.
+</h5>
 
 <div class="row">
 

--- a/download/index.md
+++ b/download/index.md
@@ -8,6 +8,9 @@ children:
 - ../meta/versions.md
 ---
 
+### Apache Brooklyn is software for modelling, monitoring and managing cloud applications through autonomic blueprints.
+
+
 <div class="row">
 
 <div class="col-md-6" markdown="1">

--- a/index.md
+++ b/index.md
@@ -78,6 +78,7 @@ children:
 # <span class="text-apache">apache</span> <span class="text-brooklyn">brooklyn</span>
 
 ## Your applications, any clouds, any containers, anywhere.
+### Apache Brooklyn is software for modelling, monitoring and managing cloud applications through autonomic blueprints.
  
 <a href="#get-started" class="btn btn-primary btn-lg">Get started</a>
 <a href="https://github.com/apache/brooklyn" class="btn btn-link btn-lg"><i class="fa fa-fw fa-github"></i> View code</a>

--- a/index.md
+++ b/index.md
@@ -79,10 +79,6 @@ children:
 
 ## Your applications, any clouds, any containers, anywhere.
 
-<h4>
- Apache Brooklyn is software for modelling, monitoring and managing cloud applications through autonomic blueprints.
-</h4>
-
 <a href="#get-started" class="btn btn-primary btn-lg">Get started</a>
 <a href="https://github.com/apache/brooklyn" class="btn btn-link btn-lg"><i class="fa fa-fw fa-github"></i> View code</a>
 
@@ -90,7 +86,9 @@ children:
 </section>
 
 <section class="container about">
-<h3 class="text-center">Use Apache brooklyn for &hellip;</h3>
+<h3 class="text-center">
+ Apache Brooklyn is software for managing cloud applications. Use it for:
+</h3>
 <div class="row">
 
 <div class="col-md-4" markdown="1">

--- a/index.md
+++ b/index.md
@@ -78,8 +78,11 @@ children:
 # <span class="text-apache">apache</span> <span class="text-brooklyn">brooklyn</span>
 
 ## Your applications, any clouds, any containers, anywhere.
-### Apache Brooklyn is software for modelling, monitoring and managing cloud applications through autonomic blueprints.
- 
+
+<h4>
+ Apache Brooklyn is software for modelling, monitoring and managing cloud applications through autonomic blueprints.
+</h4>
+
 <a href="#get-started" class="btn btn-primary btn-lg">Get started</a>
 <a href="https://github.com/apache/brooklyn" class="btn btn-link btn-lg"><i class="fa fa-fw fa-github"></i> View code</a>
 


### PR DESCRIPTION
See http://www.apache.org/foundation/marks/pmcs.html#naming

In particular this part:
<quote>
Every product homepage and any overview download pages for the product
must include a prominent reference to the product as "Apache Foo
software", and must include a brief one sentence description of the
function of the software product itself.
</quote>