### PR TITLE
Update download index and verify files to match published website

### DIFF
--- a/download/index.md
+++ b/download/index.md
@@ -12,39 +12,24 @@ children:
  Apache Brooklyn is software for modelling, deploying and managing cloud applications through autonomic blueprints.
 </h5>
 
+## Version {{ site.brooklyn-stable-version }} (recommended)
+Version {{ site.brooklyn-stable-version }} is the current version recommended for production use.
+
 <div class="row">
 
 <div class="col-md-6" markdown="1">
 
 <div class="panel panel-default">
   <div class="panel-heading" markdown="1">
-#### RPM Package
+#### Packages
   </div>
   <div class="panel-body" markdown="1">
 <div style="height: 9em;" markdown="1">
-Suitable for version 7 of CentOS and Red Hat Enterprise Linux.
+RPM package for version 7 of CentOS and Red Hat Enterprise Linux, and a DEB package for Ubuntu and Debian distributions.
 </div>
 
 <div class="text-center">
   <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-{{ site.brooklyn-stable-version }}/apache-brooklyn-{{ site.brooklyn-stable-version }}-1.noarch.rpm" role="button">RPM package</a>
-</div>
-  </div>
-</div>
-
-</div><!-- col -->
-
-<div class="col-md-6" markdown="1">
-
-<div class="panel panel-default">
-  <div class="panel-heading" markdown="1">
-#### DEB Package
-  </div>
-  <div class="panel-body" markdown="1">
-<div style="height: 9em;" markdown="1">
-Suitable Ubuntu and Debian distributions.
-</div>
-
-<div class="text-center">
   <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-{{ site.brooklyn-stable-version }}/apache-brooklyn-{{ site.brooklyn-stable-version }}.deb" role="button">DEB package</a>
 </div>
   </div>
@@ -121,6 +106,103 @@ contribute code changes to Apache Brooklyn, we recommend you get the source code
 
 </div><!-- col -->
 </div><!-- row -->
+
+## Version 1.0.0-M1 (preview “milestone” release)
+Version 1.0.0-M1 is the first milestone to our 1.0.0 release.
+
+<div class="row">
+
+<div class="col-md-6" markdown="1">
+
+<div class="panel panel-default">
+  <div class="panel-heading" markdown="1">
+#### Packages
+  </div>
+  <div class="panel-body" markdown="1">
+<div style="height: 9em;" markdown="1">
+RPM package for version 7 of CentOS and Red Hat Enterprise Linux, and a DEB package for Ubuntu and Debian distributions.
+</div>
+
+<div class="text-center">
+  <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1_1.noarch.rpm" role="button">RPM package</a>
+  <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1.deb" role="button">DEB package</a>
+</div>
+  </div>
+</div>
+
+</div><!-- col -->
+
+<div class="col-md-6" markdown="1">
+
+<div class="panel panel-default">
+  <div class="panel-heading" markdown="1">
+#### Distribution
+  </div>
+  <div class="panel-body" markdown="1">
+<div style="height: 9em;" markdown="1">
+A pre-built package that contains Apache Brooklyn and all of its dependencies in a single, easy-to-run package. 
+*Suitable for Linux and Windows servers and workstations with Java installed
+(Java 1.8 is supported, including OpenJDK, Oracle, and IBM varieties).*
+</div>
+
+<div class="text-center">
+  <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-bin.tar.gz" role="button">Tarball</a>
+  <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-bin.zip" role="button">Zip</a>
+</div>
+  </div>
+</div>
+
+</div><!-- col -->
+
+<div class="col-md-6" markdown="1">
+
+<div class="panel panel-default">
+  <div class="panel-heading" markdown="1">
+#### Command line client
+  </div>
+  <div class="panel-body" markdown="1">
+<div style="height: 6.5em;" markdown="1">
+Already got a Brooklyn server? Download just the CLI client here.
+</div>
+
+<div class="text-center" style="margin-bottom: 0.5em">
+  <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-linux.tar.gz" role="button">Linux Tarball</a>
+  <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-macosx.tar.gz" role="button">Mac OSX Tarball</a>
+  <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-windows.tar.gz" role="button">Windows Tarball</a>
+</div>
+<div class="text-center">
+  <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-linux.zip" role="button">Linux Zip</a>
+  <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-macosx.zip" role="button">Mac OSX Zip</a>
+  <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-windows.zip" role="button">Windows Zip</a>
+</div>
+  </div>
+</div>
+
+</div><!-- col -->
+<div class="col-md-6" markdown="1">
+
+<div class="panel panel-default">
+  <div class="panel-heading" markdown="1">
+#### Source Code
+  </div>
+  <div class="panel-body" markdown="1">
+<div style="height: 9em;" markdown="1">
+The source code for Apache Brooklyn. Use this to build your own binaries and make private modifications. *If you want to
+contribute code changes to Apache Brooklyn, we recommend you get the source code from version control. Visit the
+[Developers pages](../developers/index.html) to find out more.*
+</div>
+
+<div class="text-center">
+  <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-src.tar.gz" role="button">Tarball</a>
+  <a class="btn btn-default" href="https://www.apache.org/dyn/closer.lua?action=download&filename=brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-src.zip" role="button">Zip</a>
+</div>
+  </div>
+</div>
+
+</div><!-- col -->
+</div><!-- row -->
+
+## All other versions
 
 A full list of download links including Maven coordinates are [here]({{ site.path.guide }}/misc/download.html).
 <br/><br/>

--- a/download/verify.md
+++ b/download/verify.md
@@ -3,644 +3,399 @@ layout: website-normal
 title: Verify the Integrity of Downloads
 ---
 
-You can verify the integrity of the downloaded files using their PGP signatures or SHA-1 checksums.
+You can verify the integrity of the downloaded files using their PGP (GPG) signatures or SHA256 checksums.
 
 ## Verifying Hashes
 
-To verify the downloads, first get the MD5, SHA1 and/or SHA256 hashes using these links. 
+To verify the downloads, first get the GPG signatures and SHA256 hashes using these links. 
 Note that all links are for first-class Apache Software Foundation mirrors 
 so there is already reduced opportunity for anyone maliciously tampering with these files.
 
 <table class="table">
 <tr>
 <th>Artifact</th>
-<th colspan="3">Hashes</th>
+<th colspan="2">Hashes</th>
+</tr>
+<tr>
+<td>Release Manager's public keys</td>
+<td colspan="2"><a href="https://www.apache.org/dist/brooklyn/KEYS">KEYS</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-bin.tar.gz</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-bin.tar.gz.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-bin.tar.gz.sha256">sha256</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-bin.zip</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-bin.zip.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-bin.zip.sha256">sha256</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-classic.tar.gz</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-classic.tar.gz.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-classic.tar.gz.sha256">sha256</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-classic.zip</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-classic.zip.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-classic.zip.sha256">sha256</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-1.noarch.rpm</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-1.noarch.rpm.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-1.noarch.rpm.sha256">sha256</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-src.tar.gz</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-src.tar.gz.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-src.tar.gz.sha256">sha256</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-src.zip</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-src.zip.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-src.zip.sha256">sha256</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-client-cli-linux.tar.gz</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-linux.tar.gz.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-linux.tar.gz.sha256">sha256</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-client-cli-linux.zip</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-linux.zip.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-linux.zip.sha256">sha256</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-client-cli-macosx.tar.gz</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-macosx.tar.gz.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-macosx.tar.gz.sha256">sha256</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-client-cli-macosx.zip</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-macosx.zip.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-macosx.zip.sha256">sha256</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-client-cli-windows.tar.gz</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-windows.tar.gz.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-windows.tar.gz.sha256">sha256</a></td>
+</tr>
+<tr>
+<td>apache-brooklyn-1.0.0-M1-client-cli-windows.zip</td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-windows.zip.asc">pgp</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-1.0.0-M1/apache-brooklyn-1.0.0-M1-client-cli-windows.zip.sha256">sha256</a></td>
 </tr>
 
 <tr>
 <td>apache-brooklyn-0.12.0-bin.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-bin.tar.gz.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-bin.tar.gz.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-bin.tar.gz.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-bin.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.12.0-bin.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-bin.zip.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-bin.zip.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-bin.zip.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-bin.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.12.0-classic.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-classic.tar.gz.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-classic.tar.gz.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-classic.tar.gz.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-classic.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.12.0-classic.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-classic.zip.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-classic.zip.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-classic.zip.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-classic.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.12.0-1.noarch.rpm</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-1.noarch.rpm.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-1.noarch.rpm.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-1.noarch.rpm.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-1.noarch.rpm.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.12.0-src.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-src.tar.gz.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-src.tar.gz.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-src.tar.gz.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-src.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.12.0-src.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-src.zip.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-src.zip.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-src.zip.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-src.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.12.0-client-cli-linux.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-linux.tar.gz.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-linux.tar.gz.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-linux.tar.gz.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-linux.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.12.0-client-cli-linux.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-linux.zip.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-linux.zip.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-linux.zip.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-linux.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.12.0-client-cli-macosx.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-macosx.tar.gz.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-macosx.tar.gz.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-macosx.tar.gz.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-macosx.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.12.0-client-cli-macosx.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-macosx.zip.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-macosx.zip.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-macosx.zip.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-macosx.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.12.0-client-cli-windows.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-windows.tar.gz.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-windows.tar.gz.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-windows.tar.gz.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-windows.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.12.0-client-cli-windows.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-windows.zip.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-windows.zip.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-windows.zip.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-windows.zip.sha256">sha256</a></td>
 </tr>
+
 <tr>
 <td>apache-brooklyn-0.11.0-bin.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-bin.tar.gz.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-bin.tar.gz.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-bin.tar.gz.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-bin.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.11.0-bin.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-bin.zip.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-bin.zip.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-bin.zip.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-bin.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.11.0-karaf.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-karaf.tar.gz.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-karaf.tar.gz.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-karaf.tar.gz.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-karaf.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.11.0-karaf.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-karaf.zip.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-karaf.zip.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-karaf.zip.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-karaf.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.11.0-1.noarch.rpm</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-1.noarch.rpm.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-1.noarch.rpm.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-1.noarch.rpm.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-1.noarch.rpm.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.11.0-src.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-src.tar.gz.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-src.tar.gz.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-src.tar.gz.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-src.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.11.0-src.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-src.zip.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-src.zip.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-src.zip.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-src.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.11.0-client-cli-linux.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-linux.tar.gz.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-linux.tar.gz.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-linux.tar.gz.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-linux.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.11.0-client-cli-linux.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-linux.zip.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-linux.zip.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-linux.zip.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-linux.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.11.0-client-cli-macosx.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-macosx.tar.gz.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-macosx.tar.gz.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-macosx.tar.gz.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-macosx.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.11.0-client-cli-macosx.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-macosx.zip.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-macosx.zip.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-macosx.zip.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-macosx.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.11.0-client-cli-windows.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-windows.tar.gz.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-windows.tar.gz.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-windows.tar.gz.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-windows.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.11.0-client-cli-windows.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-windows.zip.md5">md5</a></td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-windows.zip.sha1">sha1</a></td>
+<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-windows.zip.asc">pgp</a></td>
 <td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-windows.zip.sha256">sha256</a></td>
 </tr>
+
 <tr>
 <td>apache-brooklyn-0.10.0-bin.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-bin.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-bin.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-bin.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-bin.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.10.0-bin.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-bin.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-bin.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-bin.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-bin.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.10.0-karaf.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-karaf.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-karaf.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-karaf.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-karaf.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.10.0-karaf.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-karaf.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-karaf.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-karaf.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-karaf.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.10.0-1.noarch.rpm</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-1.noarch.rpm.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-1.noarch.rpm.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-1.noarch.rpm.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-1.noarch.rpm.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.10.0-src.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-src.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-src.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-src.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-src.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.10.0-src.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-src.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-src.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-src.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-src.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.10.0-client-cli-linux.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-linux.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-linux.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-linux.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-linux.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.10.0-client-cli-linux.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-linux.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-linux.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-linux.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-linux.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.10.0-client-cli-macosx.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-macosx.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-macosx.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-macosx.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-macosx.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.10.0-client-cli-macosx.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-macosx.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-macosx.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-macosx.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-macosx.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.10.0-client-cli-windows.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-windows.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-windows.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-windows.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-windows.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.10.0-client-cli-windows.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-windows.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-windows.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-windows.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-windows.zip.sha256">sha256</a></td>
 </tr>
+
 <tr>
 <td>apache-brooklyn-0.9.0-bin.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-bin.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-bin.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-bin.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-bin.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.9.0-bin.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-bin.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-bin.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-bin.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-bin.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.9.0-1.noarch.rpm</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-1.noarch.rpm.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-1.noarch.rpm.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-1.noarch.rpm.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-1.noarch.rpm.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.9.0-src.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-src.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-src.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-src.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-src.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.9.0-src.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-src.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-src.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-src.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-src.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.9.0-client-cli-linux.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-linux.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-linux.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-linux.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-linux.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.9.0-client-cli-linux.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-linux.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-linux.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-linux.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-linux.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.9.0-client-cli-macosx.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-macosx.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-macosx.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-macosx.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-macosx.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.9.0-client-cli-macosx.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-macosx.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-macosx.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-macosx.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-macosx.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.9.0-client-cli-windows.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-windows.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-windows.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-windows.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-windows.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.9.0-client-cli-windows.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-windows.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-windows.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-windows.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-windows.zip.sha256">sha256</a></td>
 </tr>
+
 <tr>
 <td>apache-brooklyn-0.8.0-incubating-bin.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-bin.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-bin.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-bin.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-bin.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.8.0-incubating-bin.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-bin.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-bin.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-bin.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-bin.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.8.0-incubating-src.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-src.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-src.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-src.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-src.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.8.0-incubating-src.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-src.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-src.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-src.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-src.zip.sha256">sha256</a></td>
 </tr>
+
 <tr>
 <td>apache-brooklyn-0.7.0-incubating-bin.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-bin.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-bin.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-bin.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-bin.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.7.0-incubating-bin.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-bin.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-bin.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-bin.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-bin.zip.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.7.0-incubating-src.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-src.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-src.tar.gz.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-src.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-src.tar.gz.sha256">sha256</a></td>
 </tr>
 <tr>
 <td>apache-brooklyn-0.7.0-incubating-src.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-src.zip.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-src.zip.sha1">sha1</a></td>
+<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-src.zip.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-src.zip.sha256">sha256</a></td>
 </tr>
 <tr>
-<td>apache-brooklyn-0.7.0-M2-incubating</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/0.7.0-M2-incubating/apache-brooklyn-0.7.0-M2-incubating.tar.gz.md5">md5</a></td>
-<td><a href="https://archive.apache.org/dist/brooklyn/0.7.0-M2-incubating/apache-brooklyn-0.7.0-M2-incubating.tar.gz.sha1">sha1</a></td>
+<td>apache-brooklyn-0.7.0-M2-incubating.tar.gz</td>
+<td><a href="https://archive.apache.org/dist/brooklyn/0.7.0-M2-incubating/apache-brooklyn-0.7.0-M2-incubating.tar.gz.asc">pgp</a></td>
 <td><a href="https://archive.apache.org/dist/brooklyn/0.7.0-M2-incubating/apache-brooklyn-0.7.0-M2-incubating.tar.gz.sha256">sha256</a></td>
 </tr>
 </table>
 
-You can verify the SHA1 or SHA256 hashes easily by placing the files in the same folder as the download artifact and
+
+You can verify the SHA256 hashes easily by placing the files in the same folder as the download artifact and
 then running `shasum`, which is included in most UNIX-like systems:
 
 {% highlight bash %}
-shasum -c apache-brooklyn-{{ site.brooklyn-stable-version }}.tar.gz.sha1
 shasum -c apache-brooklyn-{{ site.brooklyn-stable-version }}.tar.gz.sha256
 {% endhighlight %}
 
-You can verify the MD5 hashes by running a command like this, and comparing the output to the contents of the `.md5` file:
-
-{% highlight bash %}
-md5 apache-brooklyn-{{ site.brooklyn-stable-version }}.tar.gz
-{% endhighlight %}
-
-
-## Verifying PGP Signatures using PGP or GPG
-
-You can download PGP/GPG signatures using these links. Note that these links are for first-class Apache
-Software Foundation mirrors so there will be reduced opportunity for tampering with these files.
-
-<table class="table">
-<tr>
-<th>Artifact</th>
-<th colspan="2">Link</th>
-</tr>
-<tr>
-<td>Release Manager's public keys</td>
-<td><a href="https://www.apache.org/dist/brooklyn/KEYS">KEYS</a></td>
-</tr>
-
-<tr>
-<td>apache-brooklyn-0.12.0-bin.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-bin.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.12.0-bin.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-bin.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.12.0-classic.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-classic.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.12.0-classic.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-classic.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.12.0-1.noarch.rpm</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-1.noarch.rpm.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.12.0-src.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-src.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.12.0-src.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-src.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.12.0-client-cli-linux.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-linux.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.12.0-client-cli-linux.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-linux.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.12.0-client-cli-macosx.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-macosx.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.12.0-client-cli-macosx.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-macosx.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.12.0-client-cli-windows.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-windows.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.12.0-client-cli-windows.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.12.0/apache-brooklyn-0.12.0-client-cli-windows.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-bin.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-bin.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-bin.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-bin.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-karaf.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-karaf.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-karaf.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-karaf.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-1.noarch.rpm</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-1.noarch.rpm.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-src.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-src.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-src.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-src.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-client-cli-linux.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-linux.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-client-cli-linux.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-linux.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-client-cli-macosx.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-macosx.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-client-cli-macosx.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-macosx.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-client-cli-windows.tar.gz</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-windows.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.11.0-client-cli-windows.zip</td>
-<td><a href="https://www.apache.org/dist/brooklyn/apache-brooklyn-0.11.0/apache-brooklyn-0.11.0-client-cli-windows.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-bin.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-bin.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-bin.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-bin.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-karaf.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-karaf.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-karaf.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-karaf.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-1.noarch.rpm</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-1.noarch.rpm.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-src.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-src.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-src.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-src.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-client-cli-linux.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-linux.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-client-cli-linux.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-linux.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-client-cli-macosx.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-macosx.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-client-cli-macosx.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-macosx.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-client-cli-windows.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-windows.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.10.0-client-cli-windows.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.10.0/apache-brooklyn-0.10.0-client-cli-windows.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.9.0-bin.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-bin.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.9.0-bin.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-bin.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.9.0-1.noarch.rpm</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-1.noarch.rpm.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.9.0-src.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-src.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.9.0-src.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-src.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.9.0-client-cli-linux.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-linux.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.9.0-client-cli-linux.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-linux.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.9.0-client-cli-macosx.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-macosx.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.9.0-client-cli-macosx.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-macosx.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.9.0-client-cli-windows.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-windows.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.9.0-client-cli-windows.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.9.0/apache-brooklyn-0.9.0-client-cli-windows.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.8.0-incubating-bin.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-bin.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.8.0-incubating-bin.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-bin.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.8.0-incubating-src.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-src.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.8.0-incubating-src.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.8.0-incubating/apache-brooklyn-0.8.0-incubating-src.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.7.0-incubating-bin.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-bin.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.7.0-incubating-bin.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-bin.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.7.0-incubating-src.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-src.tar.gz.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.7.0-incubating-src.zip</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/apache-brooklyn-0.7.0-incubating/apache-brooklyn-0.7.0-incubating-src.zip.asc">asc</a></td>
-</tr>
-<tr>
-<td>apache-brooklyn-0.7.0-M2-incubating.tar.gz</td>
-<td><a href="https://archive.apache.org/dist/brooklyn/0.7.0-M2-incubating/apache-brooklyn-0.7.0-M2-incubating.tar.gz.asc">asc</a></td>
-</tr>
-
-</table>
 
 In order to validate the release signature, download both the release `.asc` file for the release, and the `KEYS` file
 which contains the public keys of key individuals in the Apache Brooklyn project.


### PR DESCRIPTION
This is a follow up to "Add text to comply with Apache naming guidelines" #280

When I went to push the updated docs to the website I discovered the source and the published website had drifted apart a bit on the download index page and the verify page.

This PR mainly brings the `website` branch back into line with the published site, but also makes another small modification to re-instate the `KEYS` file link, which should exist on the live site but doesn't, and tidies up the introductory text on the verify page a little bit.

There are probably some other things to fix, such as broken links, but that can be done in a separate PR.

