### PR TITLE
Added documentation snippet to show how entities can be tagged and added to Quick Launch

### DIFF
--- a/guide/SUMMARY.md
+++ b/guide/SUMMARY.md
@@ -28,6 +28,7 @@
   * [Custom Entities](blueprints/custom-entities.md)
   * [Catalog](blueprints/catalog/index.md)
     * [Catalog Items YAML Syntax](blueprints/catalog/schema.md)
+    * [Adding Catalog Items to Quick Launch](blueprints/catalog/quick-launch.md)
     * [Templates and the Add-Application Wizard](blueprints/catalog/templates.md)
     * [Versioning](blueprints/catalog/versioning.md)
     * [Catalog Management](blueprints/catalog/management.md)

--- a/guide/blueprints/catalog/quick-launch.md
+++ b/guide/blueprints/catalog/quick-launch.md
@@ -1,0 +1,23 @@
+---
+title: Adding Catalog Items to Quick Launch
+---
+To add a Tomcat entity not only in the catalog, but in the Quick Launch as well, the entity must be tagged with `catalog_quick_launch`.
+This allows admins to curate what appears in the quick launch bar on the home page. 
+More tags can be added for the same entity, for other purposes.
+
+~~~ yaml
+brooklyn.catalog:
+ items:
+ - id: tomcat-server
+   version: "1.0.0"
+   itemType: entity
+   tags: [ catalog_quick_launch ]
+   item:
+     type: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
+     brooklyn.config:
+       webapp.enabledProtocols: https
+       httpsSsl:
+         url: classpath://org/apache/brooklyn/entity/webapp/sample-java-keystore.jks
+         alias: myname
+         password: mypass
+~~~

--- a/guide/blueprints/catalog/schema.md
+++ b/guide/blueprints/catalog/schema.md
@@ -52,25 +52,7 @@ brooklyn.catalog:
          password: mypass
 ~~~
 
-To add the previous Tomcat entity not only in the catalog, but in the Quick Launch as well, the entity must be tagged with `catalog_quick_launch`.
-This allows admins to curate what appears in the quick launch bar on the home page. More tags can be added for the same entity, for other purposes.
 
-~~~ yaml
-brooklyn.catalog:
- items:
- - id: tomcat-server
-   version: "1.0.0"
-   itemType: entity
-   tags: [ catalog_quick_launch ]
-   item:
-     type: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
-     brooklyn.config:
-       webapp.enabledProtocols: https
-       httpsSsl:
-         url: classpath://org/apache/brooklyn/entity/webapp/sample-java-keystore.jks
-         alias: myname
-         password: mypass
-~~~
 
 #### Catalog Metadata
 

--- a/guide/blueprints/catalog/schema.md
+++ b/guide/blueprints/catalog/schema.md
@@ -52,6 +52,25 @@ brooklyn.catalog:
          password: mypass
 ~~~
 
+To add the previous Tomcat entity not only in the catalog, but in the Quick Launch as well, the entity must be tagged with `catalog_quick_launch`.
+This allows admins to curate what appears in the quick launch bar on the home page. More tags can be added for the same entity, for other purposes.
+
+~~~ yaml
+brooklyn.catalog:
+ items:
+ - id: tomcat-server
+   version: "1.0.0"
+   itemType: entity
+   tags: [ catalog_quick_launch ]
+   item:
+     type: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
+     brooklyn.config:
+       webapp.enabledProtocols: https
+       httpsSsl:
+         url: classpath://org/apache/brooklyn/entity/webapp/sample-java-keystore.jks
+         alias: myname
+         password: mypass
+~~~
 
 #### Catalog Metadata
 


### PR DESCRIPTION
Added documentation snipped to show how entities can be tagged and added to the quick launch. 
The documentation snippet can be found in the `Catalog Items YAML Syntax`