### PR TITLE
remove references to MD5/SHA1 from release process description

### DIFF
--- a/developers/committers/release-process/make-release-artifacts.md
+++ b/developers/committers/release-process/make-release-artifacts.md
@@ -46,6 +46,6 @@ The release script will:
 3. Invoke Maven to build the source code (including running unit tests), and deploy artifacts to a Maven remote
    repository
 4. Save the .tar.gz and .zip artifacts produced by the build of `brooklyn-dist`
-5. For each of the produced files, produce MD5, SHA1, SHA256 and GnuPG signatures
+5. For each of the produced files, produce SHA256 and GnuPG signatures
 
 At the end of the script, it will show you the files it has produced and their location.

--- a/developers/committers/release-process/prerequisites.md
+++ b/developers/committers/release-process/prerequisites.md
@@ -44,8 +44,6 @@ The following software packages are required during the build. Make sure you hav
 - `gnupg2`, and `gnupg-agent` if it is packaged separately (it is on Ubuntu Linux)
 - `pinentry` for secure entry of GPG passphrases. If you are building remotely on a Linux machine, `pinentry-curses` is
   recommended; building on a mac, `port install pinentry-mac` is recommended.
-- `md5sum` and `sha1sum` - these are often present by default on Linux, but not on Mac;
-  `port install md5sha1sum` should remedy that.
 - if `gpg` does not resolve (it is needed for maven), create an alias or script pointing at `gpg2 "$@"`
 - the `mmv` command (usually in a package named `mmv`) will help with the final steps of the release process
 

--- a/developers/committers/release-process/publish-temp.md
+++ b/developers/committers/release-process/publish-temp.md
@@ -34,7 +34,7 @@ mkdir apache-brooklyn-${VERSION_NAME}-rc${RC_NUMBER}
 {% endhighlight %}
 
 Copy into this directory all of the artifacts from the previous step - `-src` and `-bin`, `.tar.gz`, `.zip` and `.rpm`,
-and all associated `.md5`, `.sha1`, `.sha256` and `.asc` signatures. Then commit:
+and all associated `.sha256` and `.asc` signatures. Then commit:
 
 {% highlight bash %}
 svn add apache-brooklyn-${VERSION_NAME}-rc${RC_NUMBER}

--- a/developers/committers/release-process/publish.md
+++ b/developers/committers/release-process/publish.md
@@ -33,7 +33,7 @@ mkdir apache-brooklyn-${VERSION_NAME}
 {% endhighlight %}
 
 Refer back to the pre-release area Subversion (see [Publish to the staging area](publish-temp.html)), and copy all of
-the release candidate artifacts - `-src` and `-bin`, `.tar.gz` and `.zip`, and all associated `.md5`, `.sha1`, `.sha256`
+the release candidate artifacts - `-src` and `-bin`, `.tar.gz` and `.zip`, and all associated `.sha256`
 and `.asc` signatures - into this new folder.
 
 Rename all of the files to remove the `-rcN` designation:
@@ -45,7 +45,7 @@ for f in *; do mv $f ${f//-rc${RC_NUMBER}/}; done
 The hash files will need patching to refer to the filenames without the `-rcN` designation:
 
 {% highlight bash %}
-sed -i.bak 's/-rc'$RC_NUMBER'-/-/' *.md5 *.sha1 *.sha256
+sed -i.bak 's/-rc'$RC_NUMBER'-/-/' *.sha256
 rm -f *.bak
 {% endhighlight %}
 
@@ -54,9 +54,7 @@ Note that the PGP signatures do not embed the filename so they do not need to be
 As a final check, re-test the hashes and signatures:
 
 {% highlight bash %}
-for artifact in $(find * -type f ! \( -name '*.asc' -o -name '*.md5' -o -name '*.sha1' -o -name '*.sha256' \) ); do
-    md5sum -c ${artifact}.md5 && \
-    shasum -a1 -c ${artifact}.sha1 && \
+for artifact in $(find * -type f ! \( -name '*.asc' -o -name '*.sha256' \) ); do
     shasum -a256 -c ${artifact}.sha256 && \
     gpg2 --verify ${artifact}.asc ${artifact} \
       || { echo "Invalid signature for $artifact. Aborting!"; break; }
@@ -151,7 +149,7 @@ git checkout master
 
 1. Edit the file `brooklyn-docs/_config.yml` - change `brooklyn-stable-version` to be the newly-release version, and
    `brooklyn-version` to be the current SNAPSHOT version on the master branch.
-2. Edit the file `brooklyn-docs/website/download/verify.md` to add links to the MD5/SHA1/SHA256 hashes and PGP signatures for the
+2. Edit the file `brooklyn-docs/website/download/verify.md` to add links to the SHA256 hashes and PGP signatures for the
    new version.
 3. Edit the file `brooklyn-docs/website/meta/versions.md` to add the new version.
 4. Build the updated site with `./_build/build.sh website-root --install`.

--- a/developers/committers/release-process/verify-release-artifacts.md
+++ b/developers/committers/release-process/verify-release-artifacts.md
@@ -7,7 +7,7 @@ navgroup: developers
 Below is described a series of "sanity checks" that should be performed before uploading the artifacts to the
 pre-release area. They are also useful for community members that want to check the artifact before voting (community
 members may also want to check the [list of required software packages](prerequisites.html#software-packages) to ensure
-they have the GnuPG and md5sum/sha1sum installed.
+they have the GnuPG installed.
 
 Setup
 -----
@@ -66,7 +66,7 @@ Check that all archives are correctly annotated with license information.
 Check NOTICE is included:
 
 {% highlight bash %}
-for ARCHIVE in $(find * -type f ! \( -name '*.asc' -o -name '*.md5' -o -name '*.sha1' -o -name '*.sha256' \) ); do
+for ARCHIVE in $(find * -type f ! \( -name '*.asc' -o -name '*.sha256' \) ); do
   REL_ARCHIVE=${ARCHIVE/-rc?}
   case $ARCHIVE in
     *.tar.gz)
@@ -98,9 +98,7 @@ Verify the hashes and signatures of artifacts
 Then check the hashes and signatures, ensuring you get a positive message from each one:
 
 {% highlight bash %}
-for artifact in $(find * -type f ! \( -name '*.asc' -o -name '*.md5' -o -name '*.sha1' -o -name '*.sha256' \) ); do
-    md5sum -c ${artifact}.md5 && \
-    shasum -a1 -c ${artifact}.sha1 && \
+for artifact in $(find * -type f ! \( -name '*.asc' -o -name '*.sha256' \) ); do
     shasum -a256 -c ${artifact}.sha256 && \
     gpg2 --verify ${artifact}.asc ${artifact} \
       || { echo "Invalid signature for $artifact. Aborting!"; break; }


### PR DESCRIPTION
Meant to do this after https://github.com/apache/brooklyn-dist/pull/150