### PR TITLE
Minor update to docs

### DIFF
--- a/guide/blueprints/advanced-example.md
+++ b/guide/blueprints/advanced-example.md
@@ -35,7 +35,7 @@ There are four blueprints that make up this application. Each of them is used to
 * [ELK](example_yaml/brooklyn-elk-catalog.bom)
 
 #### Running the example
-First, add all four blueprints to the Brooklyn Catalog. This can be done by going to the "Catalog" module, then clicking the
+First, add all four blueprints to the Brooklyn Catalog. This can be done by going to the "Catalog" component, then clicking the
 button "Upload to catalog" and selecting the above blueprints (or drag-and-drop them). Once this is done, search for an
 entity called "ELK Stack". You will be able to deploy it by clicking on the "Deploy" button from the details page.
 Note that you can also perform this operation from the quick launch panel on the homepage. Alternatively use the `br` Brooklyn

--- a/guide/blueprints/custom-entities.md
+++ b/guide/blueprints/custom-entities.md
@@ -147,7 +147,7 @@ This gives us quite a bit more power in writing our blueprint:
 
 ### Using the Catalog and Clustering
 
-The *Catalog* tab allows you to add blueprints which you can refer to in other blueprints.
+The *Catalog* component allows you to add blueprints which you can refer to in other blueprints.
 In that tab, click *+* then *YAML*, and enter the following:
 
 !CODEFILE "example_yaml/vanilla-bash-netcat-catalog.bom"

--- a/guide/blueprints/winrm/index.md
+++ b/guide/blueprints/winrm/index.md
@@ -104,9 +104,6 @@ The installation script - referred to as `/path/to/install7zip.ps1` in the examp
 
     Start-Process "msiexec" -ArgumentList '/qn','/i',$Dl -RedirectStandardOutput ( [System.IO.Path]::Combine($Path, "stdout.txt") ) -RedirectStandardError ( [System.IO.Path]::Combine($Path, "stderr.txt") ) -Wait
 
-This is only a very simple example. A more complex example can be found in the [Microsoft SQL Server blueprint in the
-Brooklyn source code]({{book.url.brooklyn_library_git}}/{{"master" if 'SNAPSHOT' in book.brooklyn_version else book.brooklyn_version}}/software/database/src/main/resources/org/apache/brooklyn/entity/database/mssql).
-
 
 Learn More
 ----------


### PR DESCRIPTION
Terminology for the main dashboard is 'components' rather than tabs.

The example for MSSQL is no longer present in the repository linked. If it has been moved elsewhere I've not been able to find out where.