### PR TITLE
Path for logo correction

### DIFF
--- a/guide/_layouts/website/page.html
+++ b/guide/_layouts/website/page.html
@@ -3,7 +3,7 @@
 {% block body %}
     <header class="page-header">
         <a href="{{book.url.brooklyn_website}}" class="navbar-brand">
-            <img src="{{book.url.brooklyn_website}}/v/latest/style/img/apache-brooklyn-logo-244px-wide.png" alt="Apache Brooklyn">
+            <img src="{{book.url.brooklyn_website}}/style/img/apache-brooklyn-logo-244px-wide.png" alt="Apache Brooklyn">
         </a>
     </header>
     {{ super() }}


### PR DESCRIPTION
I have updated the path for the header used on the documentation site.
I wasn't  showing the Apache Brooklyn text title in the header correctly
![image](https://user-images.githubusercontent.com/17095501/90384611-bf196a80-e079-11ea-977b-61290ce942b7.png)
