### PR TITLE
Updated versions and javadoc link

### DIFF
--- a/book.json
+++ b/book.json
@@ -99,7 +99,7 @@
     }
   },
   "variables": {
-    "brooklyn_version": "1.0.0",
+    "brooklyn_version": "1.1.0-SNAPSHOT",
     "brooklyn_version_stable": "1.0.0",
     "url": {
       "brooklyn_website": "https://brooklyn.apache.org",

--- a/guide/SUMMARY.md
+++ b/guide/SUMMARY.md
@@ -152,7 +152,7 @@
 * [Logging](dev/tips/logging.md)
 * [Brooklyn Remote Debugging](dev/tips/debugging-remote-brooklyn.md)
 * [GitHub](http://github.com/apache/brooklyn)
-* [Javadoc]({{book.url.brooklyn_javadoc}})
+* [Javadoc](https://brooklyn.apache.org/v/latest/misc/javadoc)
 
 ----
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "book": "gitbook build",
     "serve": "gitbook serve",
     "pdf": "gitbook pdf",
-    "javadoc": "lessc javadoc/javadoc.less javadoc/stylesheet.css && pushd javadoc && ./build.sh && popd",
+    "javadoc": "bash -c 'lessc javadoc/javadoc.less javadoc/stylesheet.css && pushd javadoc && ./build.sh && popd'",
     "build": "npm run book && npm run javadoc"
   },
   "author": "",


### PR DESCRIPTION
Corrected Javadoc link in the template to show the latest URL
Updated current version
Added coercion to use bash for negerate the Javadoc