### PR TITLE
Use absolute docs paths in ansible guide

### DIFF
--- a/guide/blueprints/ansible/index.md
+++ b/guide/blueprints/ansible/index.md
@@ -11,6 +11,6 @@ This guide describes how Brooklyn entities can be created using the Ansible infr
 At present Brooklyn provides basic support for Ansible, operating in a 'masterless' mode. 
 Comments on this support and suggestions for further development are welcome.
 
-This guide assumes you are familiar with the basics of [creating YAML blueprints](../../blueprints).
+This guide assumes you are familiar with the basics of [creating YAML blueprints](/guide/blueprints).
 
 {% include list-children.html %}


### PR DESCRIPTION
Signed-off-by: Mykola Mandra <mykola.mandra@cloudsoft.io>