### PR TITLE
Correct workflow variables and expressions example

### DIFF
--- a/guide/blueprints/workflow/variables.md
+++ b/guide/blueprints/workflow/variables.md
@@ -14,7 +14,7 @@ For example, you can write:
 - let integer x = 1
 - id: log
   step:  log The value for x is now ${x}
-- let x = ${x} + 1
+- step: let x = ${x} + 1
   next: log
   condition:
     target: ${x}


### PR DESCRIPTION
Adds a missing -step: to the 5th line of the example