### PR TITLE
change enricherType to type

### DIFF
--- a/guide/blueprints/example_yaml/vanilla-bash-netcat-w-client.yaml
+++ b/guide/blueprints/example_yaml/vanilla-bash-netcat-w-client.yaml
@@ -78,7 +78,7 @@ services:
 
 # and add an enricher at the root so all sensors from netcat-server are visible on the root
 brooklyn.enrichers:
-- enricherType: org.apache.brooklyn.enricher.stock.Propagator
+- type: org.apache.brooklyn.enricher.stock.Propagator
   brooklyn.config:
     enricher.producer: $brooklyn:entity("netcat-server")
     enricher.propagating.propagatingAll: true


### PR DESCRIPTION
Blueprint used old syntax enricher type which isn't supported in the UI. Changed to type.