### PR TITLE
Fixes incorrect filename in aws-cfn-stacks docs

### DIFF
--- a/guide/blueprints/workflow/examples/aws-cfn-stacks/index.md
+++ b/guide/blueprints/workflow/examples/aws-cfn-stacks/index.md
@@ -14,7 +14,7 @@ This example shows how CloudFormation stacks in AWS can be synchronized.
 Firstly, we define our type to represent discovered stack and be able to refresh `on_update`:
 
 {% highlight yaml %}
-{% readj aws-cfn-type.yaml %}
+{% readj aws-cfn-type.bom %}
 {% endhighlight %}
 
 This should be added to the catalog.


### PR DESCRIPTION
Fixes an incorrectly referenced filename (aws-cfn-type.yaml -> aws-cfn-type.bom)