### PR TITLE
fix few more broken links

### DIFF
--- a/guide/blueprints/chef/creating-blueprints.md
+++ b/guide/blueprints/chef/creating-blueprints.md
@@ -15,7 +15,7 @@ An illustrative example is below:
 *This works without any installation: try it now, copying-and-pasting to the Brooklyn console.
 (Don't forget to add your preferred `location: some-cloud` to the spec.)*  
 
-Notice, if you target `google-compute-engine` location, you may need to specify `bind_address: 0.0.0.0` for the `mysql` cookbook, as described [here](https://github.com/sous-chefs/mysql/blob/main/documentation/resource_mysql_service.md#parameters).
+Notice, if you target `google-compute-engine` location, you may need to specify `bind_address: 0.0.0.0` for the `mysql` cookbook, as described [here](https://github.com/sous-chefs/mysql/blob/main/documentation/resource_mysql_service.md).
 
 We'll now walk through the important constituent parts,
 and then proceed to describing things which can be done to simplify the deployment.

--- a/guide/locations/_AWS.md
+++ b/guide/locations/_AWS.md
@@ -79,7 +79,7 @@ and speed things up.
 
 First, in the AWS Console, open the EC2 service in the region you are interested in,
 then click "Key Pairs" at the left.  For `us-east-1`, the link is 
-[here](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#KeyPairs:sort=keyName).
+[here](https://console.aws.amazon.com/ec2/v2/home?region=us-east-1).
 Click "Create Key Pair" (or "Import Key Pair" if you want to provide a public key) and
 follow the instructions.
 

--- a/guide/start/running.md
+++ b/guide/start/running.md
@@ -9,7 +9,7 @@ This guide will walk you through deploying an example 3-tier web application to 
 
 Two methods of deployment are detailed in this tutorial, using virtualisation with Vagrant and an install in your own environment (such as your local machine or in your private/public cloud). 
 
-The latter assumes that you have a [Java Runtime Environment (JRE)](https://www.java.com){:target="_blank"} installed (version 7 or later), as Brooklyn is Java under the covers. 
+The latter assumes that you have a Java Runtime Environment installed (version 7 or later), as Brooklyn is Java under the covers. 
 
 To get you up-and-running quickly, the Vagrant option will provision four compute nodes for you to deploy applications to. 
 

--- a/website/learnmore/theory.md
+++ b/website/learnmore/theory.md
@@ -173,7 +173,7 @@ model.
 ### Standards
 
 Finally we note some emerging standards in this area. OASIS CAMP 
-(<a href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=camp#technical">Cloud Application Management for Platforms</a>) 
+(<a href="https://docs.oasis-open.org/camp/camp-ta/v1.1/camp-ta-v1.1.html">Cloud Application Management for Platforms</a>) 
 and TOSCA 
 (<a href="https://www.oasis-open.org/committees/tosca/">Topology and Orchestration Specification for Cloud Applications</a>) 
 both define YAML application models similar to Brooklyn's. 


### PR DESCRIPTION
* oasis camp - now poinitng to the docs as comitee does not seem valid anymore
* removed links to java.com as they throw 403 - I guess everyone looking at brooklyun/amp docs will know how to find main java page anyway
* removed sorting hash for aws console link - not needed in the context