### PR TITLE
BROOKLYN-636 FIx Issues the Brooklyn Website caused by the CSP

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<link href="{% dependency_url bootstrap.css %}" rel="stylesheet" />
+<link href="{{site.path.style | relative_url}}/deps/bootstrap.min.css" rel="stylesheet" />
 <link href="{{site.path.style | relative_url}}/deps/octicons/octicons.css" rel="stylesheet" />
 <link href="{{site.path.style | relative_url}}/deps/bootstrap-theme.css" rel="stylesheet" />
 <link href="{{site.path.style | relative_url}}/deps/font-awesome-4.2.0/css/font-awesome.min.css" rel="stylesheet" />
@@ -11,4 +11,4 @@
 <link href="{{site.path.style | relative_url}}/css/code.css" rel="stylesheet" />
 <link href="{{site.path.style | relative_url}}/css/website.css" rel="stylesheet" />
 
-<script type="text/javascript" src="{% dependency_url jquery.js %}"></script>
+<script type="text/javascript" src="{{site.path.style | relative_url}}/deps/jquery.js"></script>

--- a/website/learnmore/catalog/catalog-item.html
+++ b/website/learnmore/catalog/catalog-item.html
@@ -28,7 +28,7 @@ under the License.
 
   {% include head.html %}
   <meta http-equiv="content-type" content="text/html; charset=iso-8859-1"/>
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{{site.path.style | relative_url}}/deps/bootstrap.min.css">
   <link rel="stylesheet" href="{{site.path.style | relative_url}}/css/catalog_items.css" type="text/css" media="screen"/>
 </head>
 <body>
@@ -50,8 +50,8 @@ under the License.
 </div>
 
 <script src="{{site.path.style | relative_url}}/js/underscore-min.js" type="text/javascript"></script>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" type="text/javascript"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+<script src="{{site.path.style | relative_url}}/deps/jquery.min.js" type="text/javascript"></script>
+<script src="{{site.path.style | relative_url}}/deps/bootstrap.min.js"></script>
 <script src="{{site.path.style | relative_url}}/js/catalog/common.js" type="text/javascript"></script>
 <script src="{{site.path.style | relative_url}}/js/catalog/items.js" type="text/javascript"></script>
 

--- a/website/learnmore/catalog/index.html
+++ b/website/learnmore/catalog/index.html
@@ -61,9 +61,9 @@ under the License.
   </div>
 </div>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js" type="text/javascript"></script>
+<script src="{{site.path.style | relative_url}}/deps/jquery.min.js" type="text/javascript"></script>
 <script src="{{site.path.style | relative_url}}/js/underscore-min.js" type="text/javascript"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+<script src="{{site.path.style | relative_url}}/deps/bootstrap.min.js"></script>
 <script src="{{site.path.style | relative_url}}/js/catalog/bloodhound.js" type="text/javascript"></script>
 <script src="{{site.path.style | relative_url}}/js/catalog/common.js" type="text/javascript"></script>
 <script type="text/javascript">


### PR DESCRIPTION
The Infra team implemented a **_Content Security Policy_** (CSP) at the start of March 2025 which blocks the loading of resources from third parties.

This has blocked the [Brooklyn Website](https://brooklyn.apache.org/) from loading **_bootstrap_** and **_jQuery_** files which has resulted in rendering problems.

Local versions of **_bootstrap_** and **_jQuery_** are already in the style/deps folder and the website just needs to be changed to use them rather than external versions.